### PR TITLE
Fix IDOR vulnerability with ShopOwnershipMiddleware + order integration tests

### DIFF
--- a/database/migrations/functions/000007_create_function_create_order.up.sql
+++ b/database/migrations/functions/000007_create_function_create_order.up.sql
@@ -22,6 +22,9 @@ CREATE OR REPLACE FUNCTION create_order(
     p_delivery_method_id bigint,
     p_delivery_method_code text,
     p_delivery_method_name text,
+    p_delivery_zone_id bigint,
+    p_delivery_zone_name text,
+    p_delivery_zone_price double precision,
     p_shipping_cost double precision,
     p_items jsonb  -- [{product_id, product_name, product_image_url, base_price, is_promotional, promotional_price, quantity, unit_price, total_price, notes, selected_options: [{variant_id, option_id, variant_name, option_name, option_price, quantity}]}]
 ) RETURNS jsonb AS $$
@@ -58,6 +61,7 @@ BEGIN
         customer_address_name, customer_address_place_id, customer_address_lat, customer_address_lng,
         payment_method_id, payment_method_code, payment_method_name,
         delivery_method_id, delivery_method_code, delivery_method_name,
+        delivery_zone_id, delivery_zone_name, delivery_zone_price,
         subtotal, shipping_cost, total
     ) VALUES (
         v_order_number,
@@ -67,6 +71,7 @@ BEGIN
         p_customer_address_name, p_customer_address_place_id, p_customer_address_lat, p_customer_address_lng,
         p_payment_method_id, p_payment_method_code, p_payment_method_name,
         p_delivery_method_id, p_delivery_method_code, p_delivery_method_name,
+        p_delivery_zone_id, p_delivery_zone_name, p_delivery_zone_price,
         v_subtotal, COALESCE(p_shipping_cost, 0), v_total
     ) RETURNING id, created_at INTO v_order_id, v_created_at;
 

--- a/internal/application/services/order_service_test.go
+++ b/internal/application/services/order_service_test.go
@@ -204,6 +204,43 @@ func TestOrderService_Create(t *testing.T) {
 		assert.Equal(t, 200.00, order.Items[0].TotalPrice)
 	})
 
+	t.Run("when order has delivery zone then preserves zone data to repository", func(t *testing.T) {
+		// Arrange
+		ctx := context.Background()
+		order := newTestOrder()
+		order.DeliveryMethod.DeliveryZones = []*models.DeliveryZone{
+			{ID: 5, Name: "Zona Norte", Price: 25.00},
+		}
+		order.ShippingCost = 25.00
+		order.Total = 225.00
+		store := newTestStore()
+
+		expectedOrder := newTestOrder()
+		expectedOrder.ID = 1
+		expectedOrder.DeliveryMethod.DeliveryZones = []*models.DeliveryZone{
+			{ID: 5, Name: "Zona Norte", Price: 25.00},
+		}
+
+		orderRepoMock := mocks.NewOrderRepository(t)
+		orderRepoMock.EXPECT().
+			Create(ctx, order).
+			Return(expectedOrder, nil)
+
+		service := NewOrderService(orderRepoMock)
+
+		// Act
+		result, err := service.Create(ctx, order, store)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.DeliveryMethod)
+		assert.Len(t, result.DeliveryMethod.DeliveryZones, 1)
+		assert.Equal(t, 5, result.DeliveryMethod.DeliveryZones[0].ID)
+		assert.Equal(t, "Zona Norte", result.DeliveryMethod.DeliveryZones[0].Name)
+		assert.Equal(t, 25.00, result.DeliveryMethod.DeliveryZones[0].Price)
+	})
+
 	t.Run("when multiple items with correct totals then passes validation", func(t *testing.T) {
 		// Arrange
 		ctx := context.Background()

--- a/internal/infraestructure/adapters/http/middleware/shop_ownership.go
+++ b/internal/infraestructure/adapters/http/middleware/shop_ownership.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/auth/claims"
+	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/errors"
+	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/logs"
+)
+
+// Shop ownership log field constants
+const (
+	ShopOwnershipMiddlewareField = "shop_ownership_middleware"
+)
+
+// ShopOwnershipMiddleware verifies that the authenticated user owns the shop
+// referenced by {shop_id} in the URL path. Must be applied after AuthMiddleware.
+type ShopOwnershipMiddleware struct{}
+
+// NewShopOwnershipMiddleware creates a new ShopOwnershipMiddleware instance.
+func NewShopOwnershipMiddleware() *ShopOwnershipMiddleware {
+	return &ShopOwnershipMiddleware{}
+}
+
+// Authorize is a middleware that checks if the authenticated user owns the shop
+// identified by the {shop_id} URL path variable.
+func (m *ShopOwnershipMiddleware) Authorize(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		shopIDStr, exists := vars["shop_id"]
+		if !exists {
+			// No shop_id in URL — not applicable, pass through
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		shopID, err := strconv.Atoi(shopIDStr)
+		if err != nil || shopID <= 0 {
+			logs.WithFields(map[string]interface{}{
+				"file":    ShopOwnershipMiddlewareField,
+				"path":    r.URL.Path,
+				"method":  r.Method,
+				"shop_id": shopIDStr,
+			}).Warn("Invalid shop_id format")
+			errors.HandleError(w, &errors.BadRequestError{Message: "invalid_shop_id_format"})
+			return
+		}
+
+		shopIDs := claims.GetShopIDsFromContext(r.Context())
+		if !userOwnsShop(shopIDs, shopID) {
+			logs.WithFields(map[string]interface{}{
+				"file":       ShopOwnershipMiddlewareField,
+				"path":       r.URL.Path,
+				"method":     r.Method,
+				"shop_id":    shopID,
+				"user_shops": shopIDs,
+			}).Warn("Access denied to shop")
+			errors.HandleError(w, &errors.ForbiddenError{Message: "access_denied_to_shop"})
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// userOwnsShop checks if the authenticated user owns the given shop.
+func userOwnsShop(userShopIDs []int, shopID int) bool {
+	for _, id := range userShopIDs {
+		if id == shopID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infraestructure/adapters/http/middleware/shop_ownership_test.go
+++ b/internal/infraestructure/adapters/http/middleware/shop_ownership_test.go
@@ -1,0 +1,113 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/auth/claims"
+)
+
+// passthrough handler that returns 200 OK
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+func contextWithShopIDs(shopIDs []int) context.Context {
+	return context.WithValue(context.Background(), claims.KeyShopIDs, shopIDs)
+}
+
+func TestShopOwnershipMiddleware_Authorize(t *testing.T) {
+	mw := NewShopOwnershipMiddleware()
+
+	t.Run("when user owns shop then passes through with 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/shops/1/orders", nil)
+		req = req.WithContext(contextWithShopIDs([]int{1, 2, 3}))
+		req = mux.SetURLVars(req, map[string]string{"shop_id": "1"})
+		rr := httptest.NewRecorder()
+
+		mw.Authorize(okHandler).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("when user does not own shop then returns 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/shops/1/orders", nil)
+		req = req.WithContext(contextWithShopIDs([]int{99}))
+		req = mux.SetURLVars(req, map[string]string{"shop_id": "1"})
+		rr := httptest.NewRecorder()
+
+		mw.Authorize(okHandler).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("when user has empty shop IDs then returns 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/shops/1/orders", nil)
+		req = req.WithContext(contextWithShopIDs([]int{}))
+		req = mux.SetURLVars(req, map[string]string{"shop_id": "1"})
+		rr := httptest.NewRecorder()
+
+		mw.Authorize(okHandler).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("when user has nil shop IDs (no context) then returns 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/shops/1/orders", nil)
+		// No shop IDs in context at all
+		req = mux.SetURLVars(req, map[string]string{"shop_id": "1"})
+		rr := httptest.NewRecorder()
+
+		mw.Authorize(okHandler).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("when shop_id is not numeric then returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/shops/abc/orders", nil)
+		req = req.WithContext(contextWithShopIDs([]int{1}))
+		req = mux.SetURLVars(req, map[string]string{"shop_id": "abc"})
+		rr := httptest.NewRecorder()
+
+		mw.Authorize(okHandler).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("when shop_id is zero then returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/shops/0/orders", nil)
+		req = req.WithContext(contextWithShopIDs([]int{1}))
+		req = mux.SetURLVars(req, map[string]string{"shop_id": "0"})
+		rr := httptest.NewRecorder()
+
+		mw.Authorize(okHandler).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("when shop_id is negative then returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/shops/-1/orders", nil)
+		req = req.WithContext(contextWithShopIDs([]int{1}))
+		req = mux.SetURLVars(req, map[string]string{"shop_id": "-1"})
+		rr := httptest.NewRecorder()
+
+		mw.Authorize(okHandler).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("when shop_id not present in URL then passes through", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/some/other/path", nil)
+		req = mux.SetURLVars(req, map[string]string{})
+		rr := httptest.NewRecorder()
+
+		mw.Authorize(okHandler).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}

--- a/internal/infraestructure/adapters/http/order_handler.go
+++ b/internal/infraestructure/adapters/http/order_handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/mlgaray/ecommerce_api/internal/core/ports"
-	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/auth/claims"
 	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/requests"
 	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/responses"
 	httpErrors "github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/errors"
@@ -151,21 +150,7 @@ func (h *OrderHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 3. Authorization: verify user owns this shop
-	shopIDs := claims.GetShopIDsFromContext(ctx)
-	if !h.userOwnsShop(shopIDs, shopID) {
-		logs.WithFields(map[string]interface{}{
-			"file":       OrderHandlerField,
-			"function":   UpdateOrderFunctionField,
-			"shop_id":    shopID,
-			"order_id":   orderID,
-			"user_shops": shopIDs,
-		}).Warn("Unauthorized access attempt to update order")
-		httpErrors.HandleError(w, &httpErrors.ForbiddenError{Message: "access_denied_to_shop"})
-		return
-	}
-
-	// 4. Parse JSON body
+	// 3. Parse JSON body
 	var request requests.UpdateOrderRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		logs.WithFields(map[string]interface{}{
@@ -179,7 +164,7 @@ func (h *OrderHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 5. Validate HTTP request (format, types)
+	// 4. Validate HTTP request (format, types)
 	if err := request.Validate(); err != nil {
 		logs.WithFields(map[string]interface{}{
 			"file":     OrderHandlerField,
@@ -192,10 +177,10 @@ func (h *OrderHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 6. Convert to domain model
+	// 5. Convert to domain model
 	order := request.ToModel()
 
-	// 7. Execute use case
+	// 6. Execute use case
 	updatedOrder, err := h.updateOrderUseCase.Execute(ctx, shopID, orderID, order)
 	if err != nil {
 		logs.WithFields(map[string]interface{}{
@@ -354,21 +339,7 @@ func (h *OrderHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 3. Authorization: verify user owns this shop
-	shopIDs := claims.GetShopIDsFromContext(ctx)
-	if !h.userOwnsShop(shopIDs, shopID) {
-		logs.WithFields(map[string]interface{}{
-			"file":       OrderHandlerField,
-			"function":   GetOrderByIDFunctionField,
-			"shop_id":    shopID,
-			"order_id":   orderID,
-			"user_shops": shopIDs,
-		}).Warn("Unauthorized access attempt to shop orders")
-		httpErrors.HandleError(w, &httpErrors.ForbiddenError{Message: "access_denied_to_shop"})
-		return
-	}
-
-	// 4. Execute use case
+	// 3. Execute use case
 	order, err := h.getOrderByIDUseCase.Execute(ctx, shopID, orderID)
 	if err != nil {
 		logs.WithFields(map[string]interface{}{
@@ -426,21 +397,7 @@ func (h *OrderHandler) UpdateStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 3. Authorization: verify user owns this shop
-	shopIDs := claims.GetShopIDsFromContext(ctx)
-	if !h.userOwnsShop(shopIDs, shopID) {
-		logs.WithFields(map[string]interface{}{
-			"file":       OrderHandlerField,
-			"function":   UpdateOrderStatusFunctionField,
-			"shop_id":    shopID,
-			"order_id":   orderID,
-			"user_shops": shopIDs,
-		}).Warn("Unauthorized access attempt to update order status")
-		httpErrors.HandleError(w, &httpErrors.ForbiddenError{Message: "access_denied_to_shop"})
-		return
-	}
-
-	// 4. Parse JSON body
+	// 3. Parse JSON body
 	var request requests.UpdateOrderStatusRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		logs.WithFields(map[string]interface{}{
@@ -454,7 +411,7 @@ func (h *OrderHandler) UpdateStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 5. Validate HTTP request
+	// 4. Validate HTTP request
 	if err := request.Validate(); err != nil {
 		logs.WithFields(map[string]interface{}{
 			"file":     OrderHandlerField,
@@ -467,7 +424,7 @@ func (h *OrderHandler) UpdateStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 6. Execute use case
+	// 5. Execute use case
 	updatedOrder, err := h.updateOrderStatusUseCase.Execute(ctx, shopID, orderID, request.ToStatus())
 	if err != nil {
 		logs.WithFields(map[string]interface{}{
@@ -543,14 +500,4 @@ func (h *OrderHandler) parseOrderID(r *http.Request) (int, error) {
 	}
 
 	return orderID, nil
-}
-
-// userOwnsShop checks if the authenticated user owns the given shop.
-func (h *OrderHandler) userOwnsShop(userShopIDs []int, shopID int) bool {
-	for _, id := range userShopIDs {
-		if id == shopID {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/infraestructure/adapters/http/order_handler_test.go
+++ b/internal/infraestructure/adapters/http/order_handler_test.go
@@ -467,7 +467,7 @@ func TestOrderHandler_Create_WithCustomerAddress(t *testing.T) {
 // =============================================================================
 
 func TestOrderHandler_Create_WithDeliveryZone(t *testing.T) {
-	t.Run("when request has delivery zone then passes to use case", func(t *testing.T) {
+	t.Run("when request has delivery zone then maps zone data to domain model", func(t *testing.T) {
 		// Arrange
 		request := newValidOrderRequest()
 		request.Order.DeliveryMethod.DeliveryZone = &requests.OrderDeliveryZoneRequest{
@@ -477,10 +477,63 @@ func TestOrderHandler_Create_WithDeliveryZone(t *testing.T) {
 		}
 		request.Order.DeliveryMethod.ShippingCost = 25.00
 		createdOrder := newCreatedOrder()
+		createdOrder.DeliveryMethod = &models.DeliveryMethod{
+			ID:   1,
+			Name: "Retiro en local",
+			Code: "pickup",
+			DeliveryZones: []*models.DeliveryZone{
+				{ID: 5, Name: "Zona Norte", Price: 25.00},
+			},
+		}
 
 		useCaseMock := mocks.NewCreateOrderUseCase(t)
 		useCaseMock.EXPECT().
-			Execute(mock.Anything, mock.AnythingOfType("*models.Order"), "test-store").
+			Execute(mock.Anything, mock.MatchedBy(func(order *models.Order) bool {
+				return order.DeliveryMethod != nil &&
+					len(order.DeliveryMethod.DeliveryZones) == 1 &&
+					order.DeliveryMethod.DeliveryZones[0].ID == 5 &&
+					order.DeliveryMethod.DeliveryZones[0].Name == "Zona Norte" &&
+					order.DeliveryMethod.DeliveryZones[0].Price == 25.00
+			}), "test-store").
+			Return(createdOrder, nil)
+
+		handler := NewOrderHandler(useCaseMock, nil, nil, nil, nil)
+
+		body, _ := json.Marshal(request)
+		req := httptest.NewRequest(http.MethodPost, "/stores/test-store/orders", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = mux.SetURLVars(req, map[string]string{"slug": "test-store"})
+		rr := httptest.NewRecorder()
+
+		// Act
+		handler.Create(rr, req)
+
+		// Assert
+		assert.Equal(t, http.StatusCreated, rr.Code)
+
+		var response responses.CreateOrderResponse
+		err := json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		if assert.NotNil(t, response.Order) && assert.NotNil(t, response.Order.DeliveryMethod) {
+			assert.NotNil(t, response.Order.DeliveryMethod.DeliveryZone)
+			assert.Equal(t, 5, response.Order.DeliveryMethod.DeliveryZone.ID)
+			assert.Equal(t, "Zona Norte", response.Order.DeliveryMethod.DeliveryZone.Name)
+			assert.Equal(t, 25.00, response.Order.DeliveryMethod.DeliveryZone.Price)
+		}
+	})
+
+	t.Run("when request has no delivery zone then zone is nil in domain model", func(t *testing.T) {
+		// Arrange
+		request := newValidOrderRequest()
+		// No DeliveryZone set (default is nil)
+		createdOrder := newCreatedOrder()
+
+		useCaseMock := mocks.NewCreateOrderUseCase(t)
+		useCaseMock.EXPECT().
+			Execute(mock.Anything, mock.MatchedBy(func(order *models.Order) bool {
+				return order.DeliveryMethod != nil &&
+					len(order.DeliveryMethod.DeliveryZones) == 0
+			}), "test-store").
 			Return(createdOrder, nil)
 
 		handler := NewOrderHandler(useCaseMock, nil, nil, nil, nil)
@@ -532,7 +585,6 @@ func TestOrderHandler_UpdateStatus(t *testing.T) {
 		body, _ := json.Marshal(newUpdateStatusRequest("confirmed"))
 		req := httptest.NewRequest(http.MethodPatch, "/shops/1/orders/1/status", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -553,30 +605,6 @@ func TestOrderHandler_UpdateStatus(t *testing.T) {
 }
 
 // =============================================================================
-// UpdateStatus Tests - Authorization
-// =============================================================================
-
-func TestOrderHandler_UpdateStatus_Forbidden(t *testing.T) {
-	t.Run("when user does not own shop then returns 403", func(t *testing.T) {
-		// Arrange
-		handler := NewOrderHandler(nil, nil, nil, nil, nil)
-
-		body, _ := json.Marshal(newUpdateStatusRequest("confirmed"))
-		req := httptest.NewRequest(http.MethodPatch, "/shops/1/orders/1/status", bytes.NewBuffer(body))
-		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{99}))
-		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
-		rr := httptest.NewRecorder()
-
-		// Act
-		handler.UpdateStatus(rr, req)
-
-		// Assert
-		assert.Equal(t, http.StatusForbidden, rr.Code)
-	})
-}
-
-// =============================================================================
 // UpdateStatus Tests - Invalid Request
 // =============================================================================
 
@@ -588,7 +616,6 @@ func TestOrderHandler_UpdateStatus_InvalidRequest(t *testing.T) {
 		body, _ := json.Marshal(newUpdateStatusRequest(""))
 		req := httptest.NewRequest(http.MethodPatch, "/shops/1/orders/1/status", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -606,7 +633,6 @@ func TestOrderHandler_UpdateStatus_InvalidRequest(t *testing.T) {
 		body, _ := json.Marshal(newUpdateStatusRequest("invalid_status"))
 		req := httptest.NewRequest(http.MethodPatch, "/shops/1/orders/1/status", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -623,7 +649,6 @@ func TestOrderHandler_UpdateStatus_InvalidRequest(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodPatch, "/shops/1/orders/1/status", bytes.NewBuffer([]byte("invalid")))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -652,7 +677,6 @@ func TestOrderHandler_UpdateStatus_DomainErrors(t *testing.T) {
 		body, _ := json.Marshal(newUpdateStatusRequest("confirmed"))
 		req := httptest.NewRequest(http.MethodPatch, "/shops/1/orders/999/status", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "999"})
 		rr := httptest.NewRecorder()
 
@@ -675,7 +699,6 @@ func TestOrderHandler_UpdateStatus_DomainErrors(t *testing.T) {
 		body, _ := json.Marshal(newUpdateStatusRequest("completed"))
 		req := httptest.NewRequest(http.MethodPatch, "/shops/1/orders/1/status", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -698,7 +721,6 @@ func TestOrderHandler_UpdateStatus_DomainErrors(t *testing.T) {
 		body, _ := json.Marshal(newUpdateStatusRequest("confirmed"))
 		req := httptest.NewRequest(http.MethodPatch, "/shops/1/orders/1/status", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -800,7 +822,6 @@ func TestOrderHandler_Update(t *testing.T) {
 		body, _ := json.Marshal(request)
 		req := httptest.NewRequest(http.MethodPut, "/shops/1/orders/1", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -822,30 +843,6 @@ func TestOrderHandler_Update(t *testing.T) {
 }
 
 // =============================================================================
-// Update Tests - Authorization
-// =============================================================================
-
-func TestOrderHandler_Update_Forbidden(t *testing.T) {
-	t.Run("when user does not own shop then returns 403", func(t *testing.T) {
-		// Arrange
-		handler := NewOrderHandler(nil, nil, nil, nil, nil)
-
-		body, _ := json.Marshal(newValidUpdateOrderRequest())
-		req := httptest.NewRequest(http.MethodPut, "/shops/1/orders/1", bytes.NewBuffer(body))
-		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{99}))
-		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
-		rr := httptest.NewRecorder()
-
-		// Act
-		handler.Update(rr, req)
-
-		// Assert
-		assert.Equal(t, http.StatusForbidden, rr.Code)
-	})
-}
-
-// =============================================================================
 // Update Tests - Invalid Request
 // =============================================================================
 
@@ -856,7 +853,6 @@ func TestOrderHandler_Update_InvalidRequest(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodPut, "/shops/1/orders/1", bytes.NewBuffer([]byte("invalid")))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -877,7 +873,6 @@ func TestOrderHandler_Update_InvalidRequest(t *testing.T) {
 		body, _ := json.Marshal(request)
 		req := httptest.NewRequest(http.MethodPut, "/shops/1/orders/1", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -898,7 +893,6 @@ func TestOrderHandler_Update_InvalidRequest(t *testing.T) {
 		body, _ := json.Marshal(request)
 		req := httptest.NewRequest(http.MethodPut, "/shops/1/orders/1", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -929,7 +923,6 @@ func TestOrderHandler_Update_DomainErrors(t *testing.T) {
 		body, _ := json.Marshal(request)
 		req := httptest.NewRequest(http.MethodPut, "/shops/1/orders/999", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "999"})
 		rr := httptest.NewRecorder()
 
@@ -954,7 +947,6 @@ func TestOrderHandler_Update_DomainErrors(t *testing.T) {
 		body, _ := json.Marshal(request)
 		req := httptest.NewRequest(http.MethodPut, "/shops/1/orders/1", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -979,7 +971,6 @@ func TestOrderHandler_Update_DomainErrors(t *testing.T) {
 		body, _ := json.Marshal(request)
 		req := httptest.NewRequest(http.MethodPut, "/shops/1/orders/1", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(contextWithShopIDs([]int{1}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1", "order_id": "1"})
 		rr := httptest.NewRecorder()
 

--- a/internal/infraestructure/adapters/http/shop_handler.go
+++ b/internal/infraestructure/adapters/http/shop_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/mlgaray/ecommerce_api/internal/core/ports"
-	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/auth/claims"
 	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/requests"
 	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/responses"
 	httpErrors "github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/errors"
@@ -47,19 +46,6 @@ func (h *ShopHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Authorization: verify user owns this shop
-	shopIDs := claims.GetShopIDsFromContext(ctx)
-	if !h.userOwnsShop(shopIDs, shopID) {
-		logs.WithFields(map[string]interface{}{
-			"file":       ShopHandlerField,
-			"function":   GetShopByIDFunctionField,
-			"shop_id":    shopID,
-			"user_shops": shopIDs,
-		}).Warn("Unauthorized access attempt to shop")
-		httpErrors.HandleError(w, &httpErrors.ForbiddenError{Message: "access_denied_to_shop"})
-		return
-	}
-
 	// Execute use case
 	shop, err := h.getShopByID.Execute(ctx, shopID)
 	if err != nil {
@@ -93,15 +79,6 @@ func (h *ShopHandler) parseShopID(r *http.Request) (int, error) {
 	return shopID, nil
 }
 
-func (h *ShopHandler) userOwnsShop(userShopIDs []int, shopID int) bool {
-	for _, id := range userShopIDs {
-		if id == shopID {
-			return true
-		}
-	}
-	return false
-}
-
 //nolint:gocyclo // Complexity is intentional for readability - sequential request handling
 func (h *ShopHandler) Update(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -110,19 +87,6 @@ func (h *ShopHandler) Update(w http.ResponseWriter, r *http.Request) {
 	shopID, err := h.parseShopID(r)
 	if err != nil {
 		httpErrors.HandleError(w, err)
-		return
-	}
-
-	// Authorization: verify user owns this shop
-	shopIDs := claims.GetShopIDsFromContext(ctx)
-	if !h.userOwnsShop(shopIDs, shopID) {
-		logs.WithFields(map[string]interface{}{
-			"file":       ShopHandlerField,
-			"function":   UpdateShopFunctionField,
-			"shop_id":    shopID,
-			"user_shops": shopIDs,
-		}).Warn("Unauthorized access attempt to shop")
-		httpErrors.HandleError(w, &httpErrors.ForbiddenError{Message: "access_denied_to_shop"})
 		return
 	}
 

--- a/internal/infraestructure/adapters/http/shop_handler_test.go
+++ b/internal/infraestructure/adapters/http/shop_handler_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,6 @@ import (
 
 	domainErrors "github.com/mlgaray/ecommerce_api/internal/core/errors"
 	"github.com/mlgaray/ecommerce_api/internal/core/models"
-	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/auth/claims"
 	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/responses"
 	"github.com/mlgaray/ecommerce_api/mocks"
 )
@@ -42,17 +40,12 @@ func newTestShop() *models.Shop {
 	}
 }
 
-func contextWithShopIDs(shopIDs []int) context.Context {
-	ctx := context.Background()
-	return context.WithValue(ctx, claims.KeyShopIDs, shopIDs)
-}
-
 // =============================================================================
 // GetByID Tests
 // =============================================================================
 
 func TestShopHandler_GetByID(t *testing.T) {
-	t.Run("when shop exists and user owns shop then returns 200 with shop data", func(t *testing.T) {
+	t.Run("when shop exists then returns 200 with shop data", func(t *testing.T) {
 		// Arrange
 		shop := newTestShop()
 
@@ -64,7 +57,6 @@ func TestShopHandler_GetByID(t *testing.T) {
 		handler := NewShopHandler(useCaseMock, nil)
 
 		req := httptest.NewRequest(http.MethodGet, "/shops/1", nil)
-		req = req.WithContext(contextWithShopIDs([]int{1, 2, 3}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "1"})
 		rr := httptest.NewRecorder()
 
@@ -95,7 +87,6 @@ func TestShopHandler_GetByID(t *testing.T) {
 		handler := NewShopHandler(useCaseMock, nil)
 
 		req := httptest.NewRequest(http.MethodGet, "/shops/999", nil)
-		req = req.WithContext(contextWithShopIDs([]int{999}))
 		req = mux.SetURLVars(req, map[string]string{"shop_id": "999"})
 		rr := httptest.NewRecorder()
 
@@ -104,22 +95,6 @@ func TestShopHandler_GetByID(t *testing.T) {
 
 		// Assert
 		assert.Equal(t, http.StatusNotFound, rr.Code)
-	})
-
-	t.Run("when user does not own shop then returns 403", func(t *testing.T) {
-		// Arrange
-		handler := NewShopHandler(nil, nil)
-
-		req := httptest.NewRequest(http.MethodGet, "/shops/1", nil)
-		req = req.WithContext(contextWithShopIDs([]int{2, 3}))
-		req = mux.SetURLVars(req, map[string]string{"shop_id": "1"}) // User owns shops 2 and 3, not 1
-		rr := httptest.NewRecorder()
-
-		// Act
-		handler.GetByID(rr, req)
-
-		// Assert
-		assert.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
 	t.Run("when shop_id is invalid format then returns 400", func(t *testing.T) {
@@ -182,23 +157,7 @@ func TestShopHandler_GetByID(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 	})
 
-	t.Run("when user has no shops then returns 403", func(t *testing.T) {
-		// Arrange
-		handler := NewShopHandler(nil, nil)
-
-		req := httptest.NewRequest(http.MethodGet, "/shops/1", nil)
-		req = req.WithContext(contextWithShopIDs([]int{}))
-		req = mux.SetURLVars(req, map[string]string{"shop_id": "1"}) // User owns no shops
-		rr := httptest.NewRecorder()
-
-		// Act
-		handler.GetByID(rr, req)
-
-		// Assert
-		assert.Equal(t, http.StatusForbidden, rr.Code)
-	})
-
-	t.Run("when user owns single shop and requests it then returns 200", func(t *testing.T) {
+	t.Run("when shop exists with single result then returns 200", func(t *testing.T) {
 		// Arrange
 		shop := newTestShop()
 
@@ -210,8 +169,7 @@ func TestShopHandler_GetByID(t *testing.T) {
 		handler := NewShopHandler(useCaseMock, nil)
 
 		req := httptest.NewRequest(http.MethodGet, "/shops/1", nil)
-		req = req.WithContext(contextWithShopIDs([]int{1}))
-		req = mux.SetURLVars(req, map[string]string{"shop_id": "1"}) // User owns only shop 1
+		req = mux.SetURLVars(req, map[string]string{"shop_id": "1"})
 		rr := httptest.NewRecorder()
 
 		// Act
@@ -219,62 +177,6 @@ func TestShopHandler_GetByID(t *testing.T) {
 
 		// Assert
 		assert.Equal(t, http.StatusOK, rr.Code)
-	})
-}
-
-// =============================================================================
-// userOwnsShop Tests
-// =============================================================================
-
-func TestShopHandler_userOwnsShop(t *testing.T) {
-	handler := &ShopHandler{}
-
-	t.Run("when shop ID is in user shops then returns true", func(t *testing.T) {
-		// Act
-		result := handler.userOwnsShop([]int{1, 2, 3}, 2)
-
-		// Assert
-		assert.True(t, result)
-	})
-
-	t.Run("when shop ID is not in user shops then returns false", func(t *testing.T) {
-		// Act
-		result := handler.userOwnsShop([]int{1, 2, 3}, 5)
-
-		// Assert
-		assert.False(t, result)
-	})
-
-	t.Run("when user shops is empty then returns false", func(t *testing.T) {
-		// Act
-		result := handler.userOwnsShop([]int{}, 1)
-
-		// Assert
-		assert.False(t, result)
-	})
-
-	t.Run("when user shops is nil then returns false", func(t *testing.T) {
-		// Act
-		result := handler.userOwnsShop(nil, 1)
-
-		// Assert
-		assert.False(t, result)
-	})
-
-	t.Run("when shop ID is first in list then returns true", func(t *testing.T) {
-		// Act
-		result := handler.userOwnsShop([]int{5, 10, 15}, 5)
-
-		// Assert
-		assert.True(t, result)
-	})
-
-	t.Run("when shop ID is last in list then returns true", func(t *testing.T) {
-		// Act
-		result := handler.userOwnsShop([]int{5, 10, 15}, 15)
-
-		// Assert
-		assert.True(t, result)
 	})
 }
 

--- a/internal/infraestructure/adapters/repositories/postgresql/order_repository.go
+++ b/internal/infraestructure/adapters/repositories/postgresql/order_repository.go
@@ -36,6 +36,62 @@ func NewOrderRepository(dataBaseConnection DataBaseConnection) ports.OrderReposi
 	}
 }
 
+// orderFieldParams holds nullable field values extracted from an order for stored procedure calls.
+type orderFieldParams struct {
+	customerName, customerPhone, customerEmail *string
+	addressName, addressPlaceID                *string
+	addressLat, addressLng                     *float64
+	paymentMethodID                            *int
+	paymentMethodCode, paymentMethodName       *string
+	deliveryMethodID                           *int
+	deliveryMethodCode, deliveryMethodName     *string
+	deliveryZoneID                             *int
+	deliveryZoneName                           *string
+	deliveryZonePrice                          *float64
+}
+
+// extractOrderFieldParams extracts nullable fields from an order model for stored procedure parameters.
+// Used by both Create and Update to avoid code duplication.
+func (r *OrderSQLRepository) extractOrderFieldParams(order *models.Order) orderFieldParams {
+	var p orderFieldParams
+
+	if order.Customer != nil {
+		p.customerName = &order.Customer.Name
+		p.customerPhone = &order.Customer.Phone
+		p.customerEmail = &order.Customer.Email
+
+		if order.Customer.Address != nil {
+			p.addressName = &order.Customer.Address.Name
+			p.addressPlaceID = &order.Customer.Address.PlaceID
+			p.addressLat = &order.Customer.Address.Lat
+			p.addressLng = &order.Customer.Address.Lng
+		}
+	}
+
+	if order.PaymentMethod != nil {
+		p.paymentMethodID = &order.PaymentMethod.ID
+		code := string(order.PaymentMethod.Code)
+		p.paymentMethodCode = &code
+		p.paymentMethodName = &order.PaymentMethod.Name
+	}
+
+	if order.DeliveryMethod != nil {
+		p.deliveryMethodID = &order.DeliveryMethod.ID
+		code := string(order.DeliveryMethod.Code)
+		p.deliveryMethodCode = &code
+		p.deliveryMethodName = &order.DeliveryMethod.Name
+
+		if len(order.DeliveryMethod.DeliveryZones) > 0 {
+			zone := order.DeliveryMethod.DeliveryZones[0]
+			p.deliveryZoneID = &zone.ID
+			p.deliveryZoneName = &zone.Name
+			p.deliveryZonePrice = &zone.Price
+		}
+	}
+
+	return p
+}
+
 // Create creates a new order with all its items and selected options.
 // Uses stored procedure to handle transactional insert.
 func (r *OrderSQLRepository) Create(ctx context.Context, order *models.Order) (*models.Order, error) {
@@ -53,67 +109,36 @@ func (r *OrderSQLRepository) Create(ctx context.Context, order *models.Order) (*
 		return nil, fmt.Errorf("database operation failed")
 	}
 
-	// 2. Extract address fields (can be nil)
-	var addressName, addressPlaceID *string
-	var addressLat, addressLng *float64
-	if order.Customer != nil && order.Customer.Address != nil {
-		addressName = &order.Customer.Address.Name
-		addressPlaceID = &order.Customer.Address.PlaceID
-		addressLat = &order.Customer.Address.Lat
-		addressLng = &order.Customer.Address.Lng
-	}
+	// 2. Extract nullable fields from order
+	p := r.extractOrderFieldParams(order)
 
-	// 3. Extract payment method fields (can be nil)
-	var paymentMethodID *int
-	var paymentMethodCode, paymentMethodName *string
-	if order.PaymentMethod != nil {
-		paymentMethodID = &order.PaymentMethod.ID
-		code := string(order.PaymentMethod.Code)
-		paymentMethodCode = &code
-		paymentMethodName = &order.PaymentMethod.Name
-	}
-
-	// 4. Extract delivery method fields (can be nil)
-	var deliveryMethodID *int
-	var deliveryMethodCode, deliveryMethodName *string
-	if order.DeliveryMethod != nil {
-		deliveryMethodID = &order.DeliveryMethod.ID
-		code := string(order.DeliveryMethod.Code)
-		deliveryMethodCode = &code
-		deliveryMethodName = &order.DeliveryMethod.Name
-	}
-
-	// 5. Extract customer fields
-	var customerName, customerPhone, customerEmail *string
-	if order.Customer != nil {
-		customerName = &order.Customer.Name
-		customerPhone = &order.Customer.Phone
-		customerEmail = &order.Customer.Email
-	}
-
-	// 6. Call stored procedure
+	// 3. Call stored procedure
 	var resultJSON []byte
 	err = r.db.QueryRowContext(ctx, `
 		SELECT create_order(
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-			$11, $12, $13, $14, $15, $16, $17, $18
+			$11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
+			$21
 		)`,
 		order.Store.ID,
 		order.Store.Name,
 		order.Store.Slug,
-		customerName,
-		customerPhone,
-		customerEmail,
-		addressName,
-		addressPlaceID,
-		addressLat,
-		addressLng,
-		paymentMethodID,
-		paymentMethodCode,
-		paymentMethodName,
-		deliveryMethodID,
-		deliveryMethodCode,
-		deliveryMethodName,
+		p.customerName,
+		p.customerPhone,
+		p.customerEmail,
+		p.addressName,
+		p.addressPlaceID,
+		p.addressLat,
+		p.addressLng,
+		p.paymentMethodID,
+		p.paymentMethodCode,
+		p.paymentMethodName,
+		p.deliveryMethodID,
+		p.deliveryMethodCode,
+		p.deliveryMethodName,
+		p.deliveryZoneID,
+		p.deliveryZoneName,
+		p.deliveryZonePrice,
 		order.ShippingCost,
 		itemsJSON,
 	).Scan(&resultJSON)
@@ -122,7 +147,7 @@ func (r *OrderSQLRepository) Create(ctx context.Context, order *models.Order) (*
 		return r.handleCreateError(err, order.Store.ID)
 	}
 
-	// 7. Parse result
+	// 8. Parse result
 	var result struct {
 		ID           int       `json:"id"`
 		OrderNumber  string    `json:"order_number"`
@@ -143,7 +168,7 @@ func (r *OrderSQLRepository) Create(ctx context.Context, order *models.Order) (*
 		return nil, fmt.Errorf("database operation failed")
 	}
 
-	// 8. Update order with DB-generated values
+	// 9. Update order with DB-generated values
 	order.ID = result.ID
 	order.OrderNumber = result.OrderNumber
 	order.Status = models.OrderStatus(result.Status)
@@ -980,8 +1005,6 @@ func (r *OrderSQLRepository) unmarshalOrderItems(itemsJSON []byte) ([]*models.Or
 // Uses stored procedure to handle transactional update.
 // Recalculates subtotal and total from items.
 // Deletes all existing items (CASCADE handles selections) and inserts new ones.
-//
-//nolint:gocyclo // Complexity is intentional - linear field extraction for nullable delivery method/zone parameters
 func (r *OrderSQLRepository) Update(ctx context.Context, shopID int, order *models.Order) error {
 	startTime := time.Now()
 
@@ -997,56 +1020,10 @@ func (r *OrderSQLRepository) Update(ctx context.Context, shopID int, order *mode
 		return fmt.Errorf("database operation failed")
 	}
 
-	// 2. Extract address fields (can be nil)
-	var addressName, addressPlaceID *string
-	var addressLat, addressLng *float64
-	if order.Customer != nil && order.Customer.Address != nil {
-		addressName = &order.Customer.Address.Name
-		addressPlaceID = &order.Customer.Address.PlaceID
-		addressLat = &order.Customer.Address.Lat
-		addressLng = &order.Customer.Address.Lng
-	}
+	// 2. Extract nullable fields from order
+	p := r.extractOrderFieldParams(order)
 
-	// 3. Extract payment method fields (can be nil)
-	var paymentMethodID *int
-	var paymentMethodCode, paymentMethodName *string
-	if order.PaymentMethod != nil {
-		paymentMethodID = &order.PaymentMethod.ID
-		code := string(order.PaymentMethod.Code)
-		paymentMethodCode = &code
-		paymentMethodName = &order.PaymentMethod.Name
-	}
-
-	// 4. Extract delivery method fields (can be nil)
-	var deliveryMethodID *int
-	var deliveryMethodCode, deliveryMethodName *string
-	if order.DeliveryMethod != nil {
-		deliveryMethodID = &order.DeliveryMethod.ID
-		code := string(order.DeliveryMethod.Code)
-		deliveryMethodCode = &code
-		deliveryMethodName = &order.DeliveryMethod.Name
-	}
-
-	// 5. Extract delivery zone fields (can be nil)
-	var deliveryZoneID *int
-	var deliveryZoneName *string
-	var deliveryZonePrice *float64
-	if order.DeliveryMethod != nil && len(order.DeliveryMethod.DeliveryZones) > 0 {
-		zone := order.DeliveryMethod.DeliveryZones[0]
-		deliveryZoneID = &zone.ID
-		deliveryZoneName = &zone.Name
-		deliveryZonePrice = &zone.Price
-	}
-
-	// 6. Extract customer fields
-	var customerName, customerPhone, customerEmail *string
-	if order.Customer != nil {
-		customerName = &order.Customer.Name
-		customerPhone = &order.Customer.Phone
-		customerEmail = &order.Customer.Email
-	}
-
-	// 7. Call stored procedure
+	// 3. Call stored procedure
 	var resultJSON []byte
 	err = r.db.QueryRowContext(ctx, `
 		SELECT update_order(
@@ -1055,22 +1032,22 @@ func (r *OrderSQLRepository) Update(ctx context.Context, shopID int, order *mode
 		)`,
 		order.ID,
 		shopID,
-		customerName,
-		customerPhone,
-		customerEmail,
-		addressName,
-		addressPlaceID,
-		addressLat,
-		addressLng,
-		paymentMethodID,
-		paymentMethodCode,
-		paymentMethodName,
-		deliveryMethodID,
-		deliveryMethodCode,
-		deliveryMethodName,
-		deliveryZoneID,
-		deliveryZoneName,
-		deliveryZonePrice,
+		p.customerName,
+		p.customerPhone,
+		p.customerEmail,
+		p.addressName,
+		p.addressPlaceID,
+		p.addressLat,
+		p.addressLng,
+		p.paymentMethodID,
+		p.paymentMethodCode,
+		p.paymentMethodName,
+		p.deliveryMethodID,
+		p.deliveryMethodCode,
+		p.deliveryMethodName,
+		p.deliveryZoneID,
+		p.deliveryZoneName,
+		p.deliveryZonePrice,
 		order.ShippingCost,
 		itemsJSON,
 	).Scan(&resultJSON)

--- a/internal/infraestructure/server/router.go
+++ b/internal/infraestructure/server/router.go
@@ -15,16 +15,17 @@ type Router interface {
 	RouteApp() *mux.Router
 }
 type router struct {
-	router          *mux.Router
-	authHandler     ports.AuthHandler
-	healthHandler   ports.HealthHandler
-	productHandler  ports.ProductHandler
-	categoryHandler ports.CategoryHandler
-	shopHandler     ports.ShopHandler
-	storeHandler    ports.StoreHandler
-	orderHandler    ports.OrderHandler
-	orderWSHandler  *httpAdapter.OrderWSHandler
-	authMiddleware  *middleware.AuthMiddleware
+	router                  *mux.Router
+	authHandler             ports.AuthHandler
+	healthHandler           ports.HealthHandler
+	productHandler          ports.ProductHandler
+	categoryHandler         ports.CategoryHandler
+	shopHandler             ports.ShopHandler
+	storeHandler            ports.StoreHandler
+	orderHandler            ports.OrderHandler
+	orderWSHandler          *httpAdapter.OrderWSHandler
+	authMiddleware          *middleware.AuthMiddleware
+	shopOwnershipMiddleware *middleware.ShopOwnershipMiddleware
 }
 
 func NewRouter(
@@ -37,21 +38,23 @@ func NewRouter(
 	orderHandler ports.OrderHandler,
 	orderWSHandler *httpAdapter.OrderWSHandler,
 	authMiddleware *middleware.AuthMiddleware,
+	shopOwnershipMiddleware *middleware.ShopOwnershipMiddleware,
 ) *router {
 	r := mux.NewRouter()
 	r.Use(middleware.Logging)
 	r.Use(middleware.PrometheusMiddleware)
 	return &router{
-		router:          r,
-		authHandler:     authHandler,
-		healthHandler:   healthHandler,
-		productHandler:  productHandler,
-		categoryHandler: categoryHandler,
-		shopHandler:     shopHandler,
-		storeHandler:    storeHandler,
-		orderHandler:    orderHandler,
-		orderWSHandler:  orderWSHandler,
-		authMiddleware:  authMiddleware,
+		router:                  r,
+		authHandler:             authHandler,
+		healthHandler:           healthHandler,
+		productHandler:          productHandler,
+		categoryHandler:         categoryHandler,
+		shopHandler:             shopHandler,
+		storeHandler:            storeHandler,
+		orderHandler:            orderHandler,
+		orderWSHandler:          orderWSHandler,
+		authMiddleware:          authMiddleware,
+		shopOwnershipMiddleware: shopOwnershipMiddleware,
 	}
 }
 
@@ -110,6 +113,7 @@ func (r *router) shopRoutes() {
 	// Protected routes (auth required)
 	protected := r.router.PathPrefix("/shops").Subrouter()
 	protected.Use(r.authMiddleware.Authenticate)
+	protected.Use(r.shopOwnershipMiddleware.Authorize)
 	// PATCH /shops/{shop_id}/orders/{order_id}/status - Update order status (owner only)
 	protected.HandleFunc("/{shop_id}/orders/{order_id:[0-9]+}/status", r.orderHandler.UpdateStatus).Methods(http.MethodPatch)
 	// PUT /shops/{shop_id}/orders/{order_id} - Update order (owner only)

--- a/main.go
+++ b/main.go
@@ -34,6 +34,9 @@ var Module = fx.Options(
 		// AUTH MIDDLEWARE
 		middleware.NewAuthMiddleware,
 
+		// SHOP OWNERSHIP MIDDLEWARE
+		middleware.NewShopOwnershipMiddleware,
+
 		// AUTH
 		fx.Annotate(http.NewAuthHandler, fx.As(new(ports.AuthHandler))),
 		fx.Annotate(services.NewAuthService, fx.As(new(ports.AuthService))),

--- a/tests/integration/features/create_order.feature
+++ b/tests/integration/features/create_order.feature
@@ -1,0 +1,83 @@
+Feature: Create order
+  As a customer
+  I want to create an order in a store
+  So that I can purchase products
+
+  Scenario: Successfully create an order with valid items
+    Given a valid order request for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 201
+    And the response should contain the created order
+    And the created order should have status "pending"
+
+  Scenario: Successfully create an order with delivery zone
+    Given a valid order request with delivery zone for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 201
+    And the created order should have status "pending"
+
+  Scenario: Successfully create an order with customer address
+    Given a valid order request with customer address for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 201
+    And the created order should have status "pending"
+
+  Scenario: Successfully create an order with selected options
+    Given a valid order request with selected options for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 201
+    And the created order should have status "pending"
+
+  Scenario: Missing customer name
+    Given an order request without customer name for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 400
+    And the user should receive an error message "customer_name_is_required"
+
+  Scenario: Missing payment method ID
+    Given an order request without payment method for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 400
+    And the user should receive an error message "payment_method_id_is_required"
+
+  Scenario: Empty items array
+    Given an order request without items for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 400
+    And the user should receive an error message "order_must_have_at_least_one_item"
+
+  Scenario: Missing delivery method ID
+    Given an order request without delivery method for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 400
+    And the user should receive an error message "delivery_method_id_is_required"
+
+  Scenario: Missing delivery method name
+    Given an order request without delivery method name for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 400
+    And the user should receive an error message "delivery_method_name_is_required"
+
+  Scenario: Invalid delivery zone ID
+    Given an order request with invalid delivery zone for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 400
+    And the user should receive an error message "delivery_zone_id_is_required"
+
+  Scenario: Subtotal mismatch
+    Given an order request with wrong subtotal for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 400
+    And the user should receive an error message "subtotal_does_not_match_calculated_subtotal"
+
+  Scenario: Total mismatch
+    Given an order request with wrong total for store "test-store"
+    When I send a create order request to store "test-store"
+    Then the response status should be 400
+    And the user should receive an error message "total_does_not_match_calculated_total"
+
+  Scenario: Store not found
+    Given a valid order request for a nonexistent store
+    When I send a create order request to store "nonexistent-store"
+    Then the response status should be 404
+    And the user should receive an error message "store_not_found"

--- a/tests/integration/features/get_all_orders.feature
+++ b/tests/integration/features/get_all_orders.feature
@@ -1,0 +1,29 @@
+Feature: Get all orders by shop
+  As a shop owner
+  I want to retrieve all orders for my shop
+  So that I can manage them from the dashboard
+
+  Background:
+    Given the user is authenticated for order operations
+
+  Scenario: Successfully retrieve orders for a shop
+    Given orders exist in shop 1
+    When I send a get all orders request for shop 1
+    Then the response status should be 200
+    And the response should contain a list of orders
+
+  Scenario: Empty orders list for shop
+    Given no orders exist in shop 1
+    When I send a get all orders request for shop 1
+    Then the response status should be 200
+    And the response should contain an empty list of orders
+
+  Scenario: Access denied to shop not owned by user
+    When I send a get all orders request for shop 999
+    Then the response status should be 403
+    And the user should receive an error message "access_denied_to_shop"
+
+  Scenario: Invalid shop ID format
+    When I send a get all orders request with invalid shop ID "abc"
+    Then the response status should be 400
+    And the user should receive an error message "invalid_shop_id_format"

--- a/tests/integration/features/get_order_by_id.feature
+++ b/tests/integration/features/get_order_by_id.feature
@@ -1,0 +1,35 @@
+Feature: Get order by ID
+  As a shop owner
+  I want to retrieve a specific order by its ID
+  So that I can see its full details
+
+  Background:
+    Given the user is authenticated for order operations
+
+  Scenario: Successfully retrieve an existing order
+    Given an order with ID 1 exists in shop 1
+    When I send a get order by ID request for shop 1 and order 1
+    Then the response status should be 200
+    And the response should contain the order details
+    And the response should contain the order items
+
+  Scenario: Order not found
+    Given an order with ID 999 does not exist in shop 1
+    When I send a get order by ID request for shop 1 and order 999
+    Then the response status should be 404
+    And the user should receive an error message "order_not_found"
+
+  Scenario: Access denied to shop not owned by user
+    When I send a get order by ID request for shop 999 and order 1
+    Then the response status should be 403
+    And the user should receive an error message "access_denied_to_shop"
+
+  Scenario: Invalid shop ID format
+    When I send a get order by ID request with invalid shop ID "abc" and order 1
+    Then the response status should be 400
+    And the user should receive an error message "invalid_shop_id_format"
+
+  Scenario: Invalid order ID - zero
+    When I send a get order by ID request for shop 1 and order 0
+    Then the response status should be 400
+    And the user should receive an error message "invalid_order_id_format"

--- a/tests/integration/features/update_order.feature
+++ b/tests/integration/features/update_order.feature
@@ -1,0 +1,48 @@
+Feature: Update order
+  As a shop owner
+  I want to update an order's data
+  So that I can modify customer info and items
+
+  Background:
+    Given the user is authenticated for order operations
+
+  Scenario: Successfully update customer and items
+    Given an editable order with ID 1 exists in shop 1
+    When I send an update order request for shop 1 and order 1
+    Then the response status should be 200
+    And the response should contain the updated order
+
+  Scenario: Successfully update with delivery zone
+    Given an editable order with ID 1 exists in shop 1 with delivery zones
+    When I send an update order request with delivery zone for shop 1 and order 1
+    Then the response status should be 200
+    And the response should contain the updated order
+
+  Scenario: Order completed cannot be edited
+    Given a completed order with ID 1 exists in shop 1
+    When I send an update order request for shop 1 and order 1
+    Then the response status should be 422
+    And the user should receive an error message "order_cannot_be_edited"
+
+  Scenario: Order cancelled cannot be edited
+    Given a cancelled order with ID 1 exists in shop 1
+    When I send an update order request for shop 1 and order 1
+    Then the response status should be 422
+    And the user should receive an error message "order_cannot_be_edited"
+
+  Scenario: Order not found
+    Given an order with ID 999 does not exist in shop 1 for update
+    When I send an update order request for shop 1 and order 999
+    Then the response status should be 404
+    And the user should receive an error message "order_not_found"
+
+  Scenario: Access denied to shop not owned by user
+    When I send an update order request for shop 999 and order 1
+    Then the response status should be 403
+    And the user should receive an error message "access_denied_to_shop"
+
+  Scenario: Subtotal mismatch on update
+    Given an editable order with ID 1 exists in shop 1 for subtotal validation
+    When I send an update order request with wrong subtotal for shop 1 and order 1
+    Then the response status should be 400
+    And the user should receive an error message "subtotal_does_not_match_calculated_subtotal"

--- a/tests/integration/features/update_order_status.feature
+++ b/tests/integration/features/update_order_status.feature
@@ -1,0 +1,53 @@
+Feature: Update order status
+  As a shop owner
+  I want to update the status of an order
+  So that I can manage the order lifecycle
+
+  Background:
+    Given the user is authenticated for order operations
+
+  Scenario: Successfully transition from pending to confirmed
+    Given an order with ID 1 in shop 1 has status "pending"
+    When I send an update order status request for shop 1 and order 1 with status "confirmed"
+    Then the response status should be 200
+    And the response should contain the order with status "confirmed"
+
+  Scenario: Successfully transition from pending to cancelled
+    Given an order with ID 1 in shop 1 has status "pending"
+    When I send an update order status request for shop 1 and order 1 with status "cancelled"
+    Then the response status should be 200
+    And the response should contain the order with status "cancelled"
+
+  Scenario: Successfully transition from confirmed to completed
+    Given an order with ID 1 in shop 1 has status "confirmed"
+    When I send an update order status request for shop 1 and order 1 with status "completed"
+    Then the response status should be 200
+    And the response should contain the order with status "completed"
+
+  Scenario: Invalid transition from pending to completed
+    Given an order with ID 1 in shop 1 has status "pending"
+    When I send an update order status request for shop 1 and order 1 with status "completed"
+    Then the response status should be 400
+    And the user should receive an error message "invalid_transition"
+
+  Scenario: Order not found
+    Given an order with ID 999 does not exist in shop 1 for status update
+    When I send an update order status request for shop 1 and order 999 with status "confirmed"
+    Then the response status should be 404
+    And the user should receive an error message "order_not_found"
+
+  Scenario: Access denied to shop not owned by user
+    When I send an update order status request for shop 999 and order 1 with status "confirmed"
+    Then the response status should be 403
+    And the user should receive an error message "access_denied_to_shop"
+
+  Scenario: Concurrent modification detected
+    Given an order with ID 1 in shop 1 has status "pending" but will be concurrently modified
+    When I send an update order status request for shop 1 and order 1 with status "confirmed"
+    Then the response status should be 409
+    And the user should receive an error message "concurrent_modification"
+
+  Scenario: Invalid order status value
+    When I send an update order status request for shop 1 and order 1 with status "xyz"
+    Then the response status should be 400
+    And the user should receive an error message "invalid_order_status"

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -62,6 +62,11 @@ func InitializeScenario(sc *godog.ScenarioContext) {
 	getStoreProductsSteps := steps.NewGetStoreProductsSteps()
 	getStoreFeaturedProductsSteps := steps.NewGetStoreFeaturedProductsSteps()
 	getStoreProductByIDSteps := steps.NewGetStoreProductByIDSteps()
+	createOrderSteps := steps.NewCreateOrderSteps()
+	getAllOrdersSteps := steps.NewGetAllOrdersSteps()
+	getOrderByIDSteps := steps.NewGetOrderByIDSteps()
+	updateOrderStatusSteps := steps.NewUpdateOrderStatusSteps()
+	updateOrderSteps := steps.NewUpdateOrderSteps()
 	commonSteps := steps.NewCommonSteps()
 
 	// Register steps
@@ -83,6 +88,11 @@ func InitializeScenario(sc *godog.ScenarioContext) {
 	getStoreProductsSteps.RegisterSteps(sc)
 	getStoreFeaturedProductsSteps.RegisterSteps(sc)
 	getStoreProductByIDSteps.RegisterSteps(sc)
+	createOrderSteps.RegisterSteps(sc)
+	getAllOrdersSteps.RegisterSteps(sc)
+	getOrderByIDSteps.RegisterSteps(sc)
+	updateOrderStatusSteps.RegisterSteps(sc)
+	updateOrderSteps.RegisterSteps(sc)
 	commonSteps.RegisterSteps(sc)
 
 	// Setup hooks

--- a/tests/integration/steps/create_order_steps.go
+++ b/tests/integration/steps/create_order_steps.go
@@ -1,0 +1,558 @@
+package steps
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cucumber/godog"
+
+	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/responses"
+)
+
+const (
+	scenarioCreateOrderValid          = "create-order-valid"
+	scenarioCreateOrderDeliveryZone   = "create-order-delivery-zone"
+	scenarioCreateOrderAddress        = "create-order-address"
+	scenarioCreateOrderOptions        = "create-order-options"
+	scenarioCreateOrderStoreNotFound  = "create-order-store-not-found"
+	scenarioCreateOrderSubtotalWrong  = "create-order-subtotal-wrong"
+	scenarioCreateOrderTotalWrong     = "create-order-total-wrong"
+	scenarioCreateOrderHTTPValidation = "create-order-http-validation"
+)
+
+type CreateOrderSteps struct{}
+
+func NewCreateOrderSteps() *CreateOrderSteps {
+	return &CreateOrderSteps{}
+}
+
+// ===== Request map helpers (satisfy errcheck for type assertions) =====
+
+func getOrderFromReq(req map[string]interface{}) (map[string]interface{}, error) {
+	order, ok := req["order"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected order map in request")
+	}
+	return order, nil
+}
+
+func getSubMap(m map[string]interface{}, key string) (map[string]interface{}, error) {
+	sub, ok := m[key].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected map for key %q", key)
+	}
+	return sub, nil
+}
+
+func getItemsSlice(m map[string]interface{}) ([]map[string]interface{}, error) {
+	items, ok := m["items"].([]map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected items slice in order")
+	}
+	return items, nil
+}
+
+// ===== Helper: build a valid order request body =====
+
+func (g *CreateOrderSteps) buildValidOrderRequest() map[string]interface{} {
+	return map[string]interface{}{
+		"order": map[string]interface{}{
+			"customer": map[string]interface{}{
+				"name":  "John Doe",
+				"phone": "1234567890",
+				"email": "john@example.com",
+			},
+			"payment_method": map[string]interface{}{
+				"id":   1,
+				"name": "Transfer",
+				"code": "transfer",
+			},
+			"delivery_method": map[string]interface{}{
+				"id":            1,
+				"name":          "Delivery",
+				"code":          "delivery",
+				"shipping_cost": 50.0,
+			},
+			"items": []map[string]interface{}{
+				{
+					"product": map[string]interface{}{
+						"id":    10,
+						"name":  "Test Product",
+						"price": 100.0,
+					},
+					"quantity":   2,
+					"unit_price": 100.0,
+				},
+			},
+			"subtotal": 200.0,
+			"total":    250.0,
+		},
+	}
+}
+
+// ===== Given Steps =====
+
+func (g *CreateOrderSteps) aValidOrderRequestForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderValid
+	ctx.requestBody = g.buildValidOrderRequest()
+	return nil
+}
+
+func (g *CreateOrderSteps) aValidOrderRequestWithDeliveryZoneForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderDeliveryZone
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	dm, err := getSubMap(order, "delivery_method")
+	if err != nil {
+		return err
+	}
+	dm["delivery_zone"] = map[string]interface{}{
+		"id":    1,
+		"name":  "Zone A",
+		"price": 50.0,
+	}
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) aValidOrderRequestWithCustomerAddressForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderAddress
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	customer, err := getSubMap(order, "customer")
+	if err != nil {
+		return err
+	}
+	customer["address"] = map[string]interface{}{
+		"name":     "Main Street 123",
+		"place_id": "ChIJ123",
+		"lat":      -34.6037,
+		"lng":      -58.3816,
+	}
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) aValidOrderRequestWithSelectedOptionsForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderOptions
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	items, err := getItemsSlice(order)
+	if err != nil {
+		return err
+	}
+	items[0]["selected_options"] = []map[string]interface{}{
+		{
+			"variant_id":   1,
+			"variant_name": "Size",
+			"option_id":    1,
+			"option_name":  "Large",
+			"option_price": 10.0,
+			"quantity":     1,
+		},
+	}
+	// Update prices to include option
+	items[0]["unit_price"] = 110.0
+	order["subtotal"] = 220.0
+	order["total"] = 270.0
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) anOrderRequestWithoutCustomerNameForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderHTTPValidation
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	customer, err := getSubMap(order, "customer")
+	if err != nil {
+		return err
+	}
+	customer["name"] = ""
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) anOrderRequestWithoutPaymentMethodForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderHTTPValidation
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	order["payment_method"] = map[string]interface{}{
+		"id":   0,
+		"name": "Transfer",
+		"code": "transfer",
+	}
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) anOrderRequestWithoutItemsForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderHTTPValidation
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	order["items"] = []map[string]interface{}{}
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) anOrderRequestWithoutDeliveryMethodForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderHTTPValidation
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	order["delivery_method"] = map[string]interface{}{
+		"id":            0,
+		"name":          "Delivery",
+		"code":          "delivery",
+		"shipping_cost": 50.0,
+	}
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) anOrderRequestWithoutDeliveryMethodNameForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderHTTPValidation
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	order["delivery_method"] = map[string]interface{}{
+		"id":            1,
+		"name":          "",
+		"code":          "delivery",
+		"shipping_cost": 50.0,
+	}
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) anOrderRequestWithInvalidDeliveryZoneForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderHTTPValidation
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	dm, err := getSubMap(order, "delivery_method")
+	if err != nil {
+		return err
+	}
+	dm["delivery_zone"] = map[string]interface{}{
+		"id":    0,
+		"name":  "Zone A",
+		"price": 50.0,
+	}
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) aValidOrderRequestForANonexistentStore() error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderStoreNotFound
+	ctx.requestBody = g.buildValidOrderRequest()
+	return nil
+}
+
+func (g *CreateOrderSteps) anOrderRequestWithWrongSubtotalForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderSubtotalWrong
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	order["subtotal"] = 999.0 // Wrong value
+	order["total"] = 1049.0   // Keep total consistent with wrong subtotal
+	ctx.requestBody = req
+	return nil
+}
+
+func (g *CreateOrderSteps) anOrderRequestWithWrongTotalForStore(slug string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioCreateOrderTotalWrong
+	req := g.buildValidOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	order["total"] = 999.0 // Wrong value
+	ctx.requestBody = req
+	return nil
+}
+
+// ===== When Steps =====
+
+func (g *CreateOrderSteps) iSendACreateOrderRequestToStore(slug string) error {
+	ctx := GetTestContext()
+
+	if ctx.app == nil {
+		if err := ctx.SetupCreateOrderTestApp(); err != nil {
+			return err
+		}
+	}
+
+	// Setup SQL expectations based on scenario
+	g.setupCreateOrderSQLExpectations(ctx, slug)
+
+	jsonBody, err := json.Marshal(ctx.requestBody)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/stores/%s/orders", ctx.server.URL, slug)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	ctx.response = resp
+	g.parseCreateOrderResponse(ctx, resp)
+
+	return nil
+}
+
+// ===== SQL Mock Setup =====
+
+func (g *CreateOrderSteps) setupCreateOrderSQLExpectations(ctx *TestContext, slug string) {
+	// Shop query columns (13 columns from shopQueryBase)
+	shopColumns := []string{
+		"id", "name", "slug", "email", "phone", "instagram", "primary_color",
+		"images", "address", "payment_methods", "delivery_methods", "operating_schedules", "timezone",
+	}
+
+	// Product query columns (9 columns from GetByIDsAndShopID)
+	productColumns := []string{
+		"id", "name", "price", "is_stockeable", "stock", "is_active",
+		"is_promotional", "promotional_price", "variants",
+	}
+
+	switch ctx.scenario {
+	case scenarioCreateOrderValid, scenarioCreateOrderAddress:
+		// Step 1: GetBySlug -> StoreService
+		shopRows := sqlmock.NewRows(shopColumns).
+			AddRow(1, "Test Store", slug, "store@test.com", "+54111234567", "@teststore", nil,
+				"[]",
+				`{"id": 1, "name": "Main St", "place_id": "ChIJ", "lat": -34.6, "lng": -58.38}`,
+				`[{"id": 1, "name": "Transfer", "code": "transfer", "is_active": true}]`,
+				`[{"id": 1, "name": "Delivery", "code": "delivery", "is_active": true, "delivery_config": {"fixed_price": 50}}]`,
+				"[]", nil)
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM shops").
+			WithArgs(slug).
+			WillReturnRows(shopRows)
+
+		// Step 2: GetByIDsAndShopID -> ValidateOrderItems
+		productRows := sqlmock.NewRows(productColumns).
+			AddRow(10, "Test Product", 100.0, false, 0, true, false, 0, "[]")
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM products").
+			WillReturnRows(productRows)
+
+		// Step 3: create_order stored procedure
+		resultJSON := `{"id": 1, "order_number": "ORD-001", "status": "pending", "subtotal": 200, "shipping_cost": 50, "total": 250, "created_at": "2026-01-01T00:00:00Z"}`
+		ctx.mockSQLMock.ExpectQuery("SELECT create_order").
+			WillReturnRows(sqlmock.NewRows([]string{"create_order"}).AddRow(resultJSON))
+
+	case scenarioCreateOrderDeliveryZone:
+		// Step 1: GetBySlug with delivery zones
+		shopRows := sqlmock.NewRows(shopColumns).
+			AddRow(1, "Test Store", slug, "store@test.com", "+54111234567", "@teststore", nil,
+				"[]",
+				`{"id": 1, "name": "Main St", "place_id": "ChIJ", "lat": -34.6, "lng": -58.38}`,
+				`[{"id": 1, "name": "Transfer", "code": "transfer", "is_active": true}]`,
+				`[{"id": 1, "name": "Delivery", "code": "delivery", "is_active": true, "delivery_zones": [{"id": 1, "name": "Zone A", "price": 50}]}]`,
+				"[]", nil)
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM shops").
+			WithArgs(slug).
+			WillReturnRows(shopRows)
+
+		// Step 2: Products
+		productRows := sqlmock.NewRows(productColumns).
+			AddRow(10, "Test Product", 100.0, false, 0, true, false, 0, "[]")
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM products").
+			WillReturnRows(productRows)
+
+		// Step 3: create_order
+		resultJSON := `{"id": 1, "order_number": "ORD-002", "status": "pending", "subtotal": 200, "shipping_cost": 50, "total": 250, "created_at": "2026-01-01T00:00:00Z"}`
+		ctx.mockSQLMock.ExpectQuery("SELECT create_order").
+			WillReturnRows(sqlmock.NewRows([]string{"create_order"}).AddRow(resultJSON))
+
+	case scenarioCreateOrderOptions:
+		// Step 1: GetBySlug
+		shopRows := sqlmock.NewRows(shopColumns).
+			AddRow(1, "Test Store", slug, "store@test.com", "+54111234567", "@teststore", nil,
+				"[]",
+				`{"id": 1, "name": "Main St", "place_id": "ChIJ", "lat": -34.6, "lng": -58.38}`,
+				`[{"id": 1, "name": "Transfer", "code": "transfer", "is_active": true}]`,
+				`[{"id": 1, "name": "Delivery", "code": "delivery", "is_active": true, "delivery_config": {"fixed_price": 50}}]`,
+				"[]", nil)
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM shops").
+			WithArgs(slug).
+			WillReturnRows(shopRows)
+
+		// Step 2: Products with variants
+		variantsJSON := `[{"id": 1, "name": "Size", "order": 1, "selection_type": "single", "max_selections": 1, "is_required": false, "options": [{"id": 1, "name": "Large", "price": 10, "order": 1}]}]`
+		productRows := sqlmock.NewRows(productColumns).
+			AddRow(10, "Test Product", 100.0, false, 0, true, false, 0, variantsJSON)
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM products").
+			WillReturnRows(productRows)
+
+		// Step 3: create_order
+		resultJSON := `{"id": 1, "order_number": "ORD-003", "status": "pending", "subtotal": 220, "shipping_cost": 50, "total": 270, "created_at": "2026-01-01T00:00:00Z"}`
+		ctx.mockSQLMock.ExpectQuery("SELECT create_order").
+			WillReturnRows(sqlmock.NewRows([]string{"create_order"}).AddRow(resultJSON))
+
+	case scenarioCreateOrderStoreNotFound:
+		// GetBySlug returns no rows
+		emptyRows := sqlmock.NewRows(shopColumns)
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM shops").
+			WithArgs(slug).
+			WillReturnRows(emptyRows)
+
+	case scenarioCreateOrderSubtotalWrong, scenarioCreateOrderTotalWrong:
+		// Step 1: GetBySlug
+		shopRows := sqlmock.NewRows(shopColumns).
+			AddRow(1, "Test Store", slug, "store@test.com", "+54111234567", "@teststore", nil,
+				"[]",
+				`{"id": 1, "name": "Main St", "place_id": "ChIJ", "lat": -34.6, "lng": -58.38}`,
+				`[{"id": 1, "name": "Transfer", "code": "transfer", "is_active": true}]`,
+				`[{"id": 1, "name": "Delivery", "code": "delivery", "is_active": true, "delivery_config": {"fixed_price": 50}}]`,
+				"[]", nil)
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM shops").
+			WithArgs(slug).
+			WillReturnRows(shopRows)
+
+		// Step 2: Products (validation passes, fails at CalculateAndValidateTotals)
+		productRows := sqlmock.NewRows(productColumns).
+			AddRow(10, "Test Product", 100.0, false, 0, true, false, 0, "[]")
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM products").
+			WillReturnRows(productRows)
+
+		// No step 3: fails before persist
+
+	case scenarioCreateOrderHTTPValidation:
+		// No SQL mock needed - fails at HTTP contract validation
+	}
+}
+
+func (g *CreateOrderSteps) parseCreateOrderResponse(ctx *TestContext, resp *http.Response) {
+	if resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		var errorResponse map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err == nil {
+			ctx.errorMessage = errorResponse["error"]
+		}
+	} else {
+		var response responses.CreateOrderResponse
+		if err := json.NewDecoder(resp.Body).Decode(&response); err == nil {
+			ctx.responseBody = response.Order
+		}
+	}
+}
+
+// ===== Then Steps =====
+
+func (g *CreateOrderSteps) theResponseShouldContainTheCreatedOrder() error {
+	ctx := GetTestContext()
+	order, ok := ctx.responseBody.(*responses.OrderResponse)
+	if !ok {
+		return fmt.Errorf("expected OrderResponse, got: %T", ctx.responseBody)
+	}
+	if order == nil || order.ID == 0 {
+		return fmt.Errorf("expected order with ID, got ID 0")
+	}
+	if order.OrderNumber == "" {
+		return fmt.Errorf("expected order with order_number, got empty")
+	}
+	if order.CreatedAt.IsZero() {
+		return fmt.Errorf("expected order with created_at, got zero")
+	}
+	return nil
+}
+
+func (g *CreateOrderSteps) theCreatedOrderShouldHaveStatus(expectedStatus string) error {
+	ctx := GetTestContext()
+	order, ok := ctx.responseBody.(*responses.OrderResponse)
+	if !ok {
+		return fmt.Errorf("expected OrderResponse, got: %T", ctx.responseBody)
+	}
+	if order == nil {
+		return fmt.Errorf("expected order in response, got nil")
+	}
+	if order.Status != expectedStatus {
+		return fmt.Errorf("expected order status '%s', got '%s'", expectedStatus, order.Status)
+	}
+	return nil
+}
+
+// ===== Register Steps =====
+
+func (g *CreateOrderSteps) RegisterSteps(sc *godog.ScenarioContext) {
+	// Given steps
+	sc.Step(`^a valid order request for store "([^"]*)"$`, g.aValidOrderRequestForStore)
+	sc.Step(`^a valid order request with delivery zone for store "([^"]*)"$`, g.aValidOrderRequestWithDeliveryZoneForStore)
+	sc.Step(`^a valid order request with customer address for store "([^"]*)"$`, g.aValidOrderRequestWithCustomerAddressForStore)
+	sc.Step(`^a valid order request with selected options for store "([^"]*)"$`, g.aValidOrderRequestWithSelectedOptionsForStore)
+	sc.Step(`^an order request without customer name for store "([^"]*)"$`, g.anOrderRequestWithoutCustomerNameForStore)
+	sc.Step(`^an order request without payment method for store "([^"]*)"$`, g.anOrderRequestWithoutPaymentMethodForStore)
+	sc.Step(`^an order request without items for store "([^"]*)"$`, g.anOrderRequestWithoutItemsForStore)
+	sc.Step(`^an order request without delivery method for store "([^"]*)"$`, g.anOrderRequestWithoutDeliveryMethodForStore)
+	sc.Step(`^an order request without delivery method name for store "([^"]*)"$`, g.anOrderRequestWithoutDeliveryMethodNameForStore)
+	sc.Step(`^an order request with invalid delivery zone for store "([^"]*)"$`, g.anOrderRequestWithInvalidDeliveryZoneForStore)
+	sc.Step(`^a valid order request for a nonexistent store$`, g.aValidOrderRequestForANonexistentStore)
+	sc.Step(`^an order request with wrong subtotal for store "([^"]*)"$`, g.anOrderRequestWithWrongSubtotalForStore)
+	sc.Step(`^an order request with wrong total for store "([^"]*)"$`, g.anOrderRequestWithWrongTotalForStore)
+
+	// When steps
+	sc.Step(`^I send a create order request to store "([^"]*)"$`, g.iSendACreateOrderRequestToStore)
+
+	// Then steps
+	sc.Step(`^the response should contain the created order$`, g.theResponseShouldContainTheCreatedOrder)
+	sc.Step(`^the created order should have status "([^"]*)"$`, g.theCreatedOrderShouldHaveStatus)
+}
+
+// Ensure time is used
+var _ = time.Now

--- a/tests/integration/steps/get_all_orders_steps.go
+++ b/tests/integration/steps/get_all_orders_steps.go
@@ -1,0 +1,233 @@
+package steps
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cucumber/godog"
+
+	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/responses"
+)
+
+const (
+	scenarioOrdersExist = "orders-exist"
+	scenarioNoOrders    = "no-orders"
+)
+
+type GetAllOrdersSteps struct{}
+
+func NewGetAllOrdersSteps() *GetAllOrdersSteps {
+	return &GetAllOrdersSteps{}
+}
+
+// ===== Given Steps =====
+
+func (g *GetAllOrdersSteps) ordersExistInShop(shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioOrdersExist
+	_ = shopID
+	return nil
+}
+
+func (g *GetAllOrdersSteps) noOrdersExistInShop(shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioNoOrders
+	_ = shopID
+	return nil
+}
+
+// ===== When Steps =====
+
+func (g *GetAllOrdersSteps) iSendAGetAllOrdersRequestForShop(shopID int) error {
+	ctx := GetTestContext()
+
+	if ctx.app == nil {
+		if err := ctx.SetupOrderTestApp(); err != nil {
+			return err
+		}
+	}
+
+	// Setup SQL expectations based on scenario
+	g.setupGetAllSQLExpectations(ctx, shopID)
+
+	url := fmt.Sprintf("%s/shops/%d/orders", ctx.server.URL, shopID)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	if ctx.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+ctx.authToken)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	ctx.response = resp
+	g.parseGetAllResponse(ctx, resp)
+
+	return nil
+}
+
+func (g *GetAllOrdersSteps) iSendAGetAllOrdersRequestWithInvalidShopID(invalidShopID string) error {
+	ctx := GetTestContext()
+
+	if ctx.app == nil {
+		if err := ctx.SetupOrderTestApp(); err != nil {
+			return err
+		}
+	}
+
+	url := fmt.Sprintf("%s/shops/%s/orders", ctx.server.URL, invalidShopID)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	if ctx.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+ctx.authToken)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	ctx.response = resp
+	g.parseGetAllResponse(ctx, resp)
+
+	return nil
+}
+
+// ===== SQL Mock Setup =====
+
+func (g *GetAllOrdersSteps) setupGetAllSQLExpectations(ctx *TestContext, shopID int) {
+	// 20 columns returned by GetAllByShopIDWithFilters query (lightweight - no items)
+	columns := []string{
+		"id", "order_number", "status",
+		"customer_name", "customer_phone", "customer_email", "customer_address_name",
+		"payment_method_id", "payment_method_code", "payment_method_name",
+		"delivery_method_id", "delivery_method_code", "delivery_method_name",
+		"delivery_zone_name",
+		"subtotal", "shipping_cost", "total",
+		"created_at", "updated_at",
+		"items_count",
+	}
+
+	// Count query columns (for first page total count)
+	countColumns := []string{"count"}
+
+	switch ctx.scenario {
+	case scenarioOrdersExist:
+		now := time.Now()
+		rows := sqlmock.NewRows(columns).
+			AddRow(
+				1, "ORD-001", "pending",
+				"John Doe", "1234567890", "john@example.com", nil,
+				1, "transfer", "Transferencia",
+				1, "delivery", "Delivery",
+				nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				2,
+			).
+			AddRow(
+				2, "ORD-002", "confirmed",
+				"Jane Doe", "0987654321", "jane@example.com", nil,
+				1, "cash", "Efectivo",
+				1, "pickup", "Retiro",
+				nil,
+				100.0, 0.0, 100.0,
+				now, now,
+				1,
+			)
+
+		ctx.mockSQLMock.ExpectQuery("SELECT").
+			WithArgs(shopID, sqlmock.AnyArg()).
+			WillReturnRows(rows)
+
+		countRows := sqlmock.NewRows(countColumns).AddRow(2)
+		ctx.mockSQLMock.ExpectQuery("SELECT COUNT").
+			WithArgs(shopID).
+			WillReturnRows(countRows)
+
+	case scenarioNoOrders:
+		emptyRows := sqlmock.NewRows(columns)
+		ctx.mockSQLMock.ExpectQuery("SELECT").
+			WithArgs(shopID, sqlmock.AnyArg()).
+			WillReturnRows(emptyRows)
+
+		countRows := sqlmock.NewRows(countColumns).AddRow(0)
+		ctx.mockSQLMock.ExpectQuery("SELECT COUNT").
+			WithArgs(shopID).
+			WillReturnRows(countRows)
+	}
+}
+
+func (g *GetAllOrdersSteps) parseGetAllResponse(ctx *TestContext, resp *http.Response) {
+	if resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		var errorResponse map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err == nil {
+			ctx.errorMessage = errorResponse["error"]
+		}
+	} else {
+		var response responses.ListOrdersResponse
+		if err := json.NewDecoder(resp.Body).Decode(&response); err == nil {
+			ctx.responseBody = &response
+		}
+	}
+}
+
+// ===== Then Steps =====
+
+func (g *GetAllOrdersSteps) theResponseShouldContainAListOfOrders() error {
+	ctx := GetTestContext()
+	response, ok := ctx.responseBody.(*responses.ListOrdersResponse)
+	if !ok {
+		return fmt.Errorf("expected ListOrdersResponse, got: %T", ctx.responseBody)
+	}
+	if len(response.Orders) == 0 {
+		return fmt.Errorf("expected orders in response, got empty list")
+	}
+	return nil
+}
+
+func (g *GetAllOrdersSteps) theResponseShouldContainAnEmptyListOfOrders() error {
+	ctx := GetTestContext()
+	response, ok := ctx.responseBody.(*responses.ListOrdersResponse)
+	if !ok {
+		return fmt.Errorf("expected ListOrdersResponse, got: %T", ctx.responseBody)
+	}
+	if len(response.Orders) != 0 {
+		return fmt.Errorf("expected empty orders list, got %d orders", len(response.Orders))
+	}
+	return nil
+}
+
+// ===== Register Steps =====
+
+func (g *GetAllOrdersSteps) RegisterSteps(sc *godog.ScenarioContext) {
+	// Given steps
+	sc.Step(`^orders exist in shop (\d+)$`, g.ordersExistInShop)
+	sc.Step(`^no orders exist in shop (\d+)$`, g.noOrdersExistInShop)
+
+	// When steps
+	sc.Step(`^I send a get all orders request for shop (\d+)$`, g.iSendAGetAllOrdersRequestForShop)
+	sc.Step(`^I send a get all orders request with invalid shop ID "([^"]*)"$`, g.iSendAGetAllOrdersRequestWithInvalidShopID)
+
+	// Then steps
+	sc.Step(`^the response should contain a list of orders$`, g.theResponseShouldContainAListOfOrders)
+	sc.Step(`^the response should contain an empty list of orders$`, g.theResponseShouldContainAnEmptyListOfOrders)
+}

--- a/tests/integration/steps/get_order_by_id_steps.go
+++ b/tests/integration/steps/get_order_by_id_steps.go
@@ -1,0 +1,239 @@
+package steps
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cucumber/godog"
+
+	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/responses"
+)
+
+const (
+	scenarioOrderExists   = "order-exists"
+	scenarioOrderNotFound = "order-not-found"
+)
+
+type GetOrderByIDSteps struct{}
+
+func NewGetOrderByIDSteps() *GetOrderByIDSteps {
+	return &GetOrderByIDSteps{}
+}
+
+// ===== Given Steps =====
+
+func (g *GetOrderByIDSteps) theUserIsAuthenticatedForOrderOperations() error {
+	ctx := GetTestContext()
+	if ctx.app == nil {
+		if err := ctx.SetupOrderTestApp(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *GetOrderByIDSteps) anOrderWithIDExistsInShop(orderID int, shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioOrderExists
+	return nil
+}
+
+func (g *GetOrderByIDSteps) anOrderWithIDDoesNotExistInShop(orderID int, shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioOrderNotFound
+	return nil
+}
+
+// ===== When Steps =====
+
+func (g *GetOrderByIDSteps) iSendAGetOrderByIDRequestForShopAndOrder(shopID int, orderID int) error {
+	ctx := GetTestContext()
+
+	if ctx.app == nil {
+		if err := ctx.SetupOrderTestApp(); err != nil {
+			return err
+		}
+	}
+
+	// Setup SQL expectations based on scenario
+	g.setupGetByIDSQLExpectations(ctx, shopID, orderID)
+
+	url := fmt.Sprintf("%s/shops/%d/orders/%d", ctx.server.URL, shopID, orderID)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	if ctx.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+ctx.authToken)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	ctx.response = resp
+	g.parseOrderResponse(ctx, resp)
+
+	return nil
+}
+
+func (g *GetOrderByIDSteps) iSendAGetOrderByIDRequestWithInvalidShopIDAndOrder(invalidShopID string, orderID int) error {
+	ctx := GetTestContext()
+
+	if ctx.app == nil {
+		if err := ctx.SetupOrderTestApp(); err != nil {
+			return err
+		}
+	}
+
+	url := fmt.Sprintf("%s/shops/%s/orders/%d", ctx.server.URL, invalidShopID, orderID)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	if ctx.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+ctx.authToken)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	ctx.response = resp
+	g.parseOrderResponse(ctx, resp)
+
+	return nil
+}
+
+// ===== SQL Mock Setup =====
+
+func (g *GetOrderByIDSteps) setupGetByIDSQLExpectations(ctx *TestContext, shopID int, orderID int) {
+	// 28 columns returned by GetByID CTE query
+	columns := []string{
+		"id", "order_number", "status",
+		"store_id", "store_name", "store_slug",
+		"customer_name", "customer_phone", "customer_email",
+		"customer_address_name", "customer_address_place_id",
+		"customer_address_lat", "customer_address_lng",
+		"payment_method_id", "payment_method_code", "payment_method_name",
+		"delivery_method_id", "delivery_method_code", "delivery_method_name",
+		"delivery_zone_id", "delivery_zone_name", "delivery_zone_price",
+		"subtotal", "shipping_cost", "total",
+		"created_at", "updated_at",
+		"items",
+	}
+
+	switch ctx.scenario {
+	case scenarioOrderExists:
+		itemsJSON := `[{"id":1,"product_id":10,"product_name":"Test Product","product_image_url":"https://img.com/p.jpg","base_price":100,"is_promotional":false,"promotional_price":0,"quantity":2,"unit_price":100,"total_price":200,"notes":"","selected_options":[]}]`
+
+		now := time.Now()
+		rows := sqlmock.NewRows(columns).
+			AddRow(
+				orderID, "ORD-001", "pending",
+				shopID, "Test Store", "test-store",
+				"John Doe", "1234567890", "john@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				itemsJSON,
+			)
+
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows)
+
+	case scenarioOrderNotFound:
+		emptyRows := sqlmock.NewRows(columns)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(emptyRows)
+	}
+}
+
+func (g *GetOrderByIDSteps) parseOrderResponse(ctx *TestContext, resp *http.Response) {
+	if resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		var errorResponse map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err == nil {
+			ctx.errorMessage = errorResponse["error"]
+		}
+	} else {
+		var response responses.GetOrderResponse
+		if err := json.NewDecoder(resp.Body).Decode(&response); err == nil {
+			ctx.responseBody = response.Order
+		}
+	}
+}
+
+// ===== Then Steps =====
+
+func (g *GetOrderByIDSteps) theResponseShouldContainTheOrderDetails() error {
+	ctx := GetTestContext()
+	order, ok := ctx.responseBody.(*responses.OrderResponse)
+	if !ok {
+		return fmt.Errorf("expected OrderResponse, got: %T", ctx.responseBody)
+	}
+	if order == nil || order.ID == 0 {
+		return fmt.Errorf("expected order with ID, got ID 0")
+	}
+	if order.OrderNumber == "" {
+		return fmt.Errorf("expected order with order_number, got empty")
+	}
+	if order.Status == "" {
+		return fmt.Errorf("expected order with status, got empty")
+	}
+	if order.Customer.Name == "" {
+		return fmt.Errorf("expected order with customer name, got empty")
+	}
+	return nil
+}
+
+func (g *GetOrderByIDSteps) theResponseShouldContainTheOrderItems() error {
+	ctx := GetTestContext()
+	order, ok := ctx.responseBody.(*responses.OrderResponse)
+	if !ok {
+		return fmt.Errorf("expected OrderResponse, got: %T", ctx.responseBody)
+	}
+	if len(order.Items) == 0 {
+		return fmt.Errorf("expected order with items, got empty")
+	}
+	return nil
+}
+
+// ===== Register Steps =====
+
+func (g *GetOrderByIDSteps) RegisterSteps(sc *godog.ScenarioContext) {
+	// Given steps
+	sc.Step(`^the user is authenticated for order operations$`, g.theUserIsAuthenticatedForOrderOperations)
+	sc.Step(`^an order with ID (\d+) exists in shop (\d+)$`, g.anOrderWithIDExistsInShop)
+	sc.Step(`^an order with ID (\d+) does not exist in shop (\d+)$`, g.anOrderWithIDDoesNotExistInShop)
+
+	// When steps
+	sc.Step(`^I send a get order by ID request for shop (\d+) and order (\d+)$`, g.iSendAGetOrderByIDRequestForShopAndOrder)
+	sc.Step(`^I send a get order by ID request with invalid shop ID "([^"]*)" and order (\d+)$`, g.iSendAGetOrderByIDRequestWithInvalidShopIDAndOrder)
+
+	// Then steps
+	sc.Step(`^the response should contain the order details$`, g.theResponseShouldContainTheOrderDetails)
+	sc.Step(`^the response should contain the order items$`, g.theResponseShouldContainTheOrderItems)
+}
+
+// Ensure sql package is used (for sql.NullString etc in other files)
+var _ = sql.ErrNoRows

--- a/tests/integration/steps/test_context.go
+++ b/tests/integration/steps/test_context.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mlgaray/ecommerce_api/internal/application/services"
 	"github.com/mlgaray/ecommerce_api/internal/application/usecases/auth"
 	"github.com/mlgaray/ecommerce_api/internal/application/usecases/category"
+	"github.com/mlgaray/ecommerce_api/internal/application/usecases/order"
 	"github.com/mlgaray/ecommerce_api/internal/application/usecases/product"
 	"github.com/mlgaray/ecommerce_api/internal/application/usecases/shop"
 	"github.com/mlgaray/ecommerce_api/internal/application/usecases/store"
@@ -452,14 +453,18 @@ func (ctx *TestContext) SetupShopTestApp() error {
 
 			// Provide handler
 			fx.Annotate(authhttp.NewShopHandler, fx.As(new(ports.ShopHandler))),
+
+			// Provide shop ownership middleware
+			middleware.NewShopOwnershipMiddleware,
 		),
-		fx.Invoke(func(handler ports.ShopHandler, authMiddleware *middleware.AuthMiddleware) {
+		fx.Invoke(func(handler ports.ShopHandler, authMiddleware *middleware.AuthMiddleware, shopOwnershipMiddleware *middleware.ShopOwnershipMiddleware) {
 			// Create HTTP router and server
 			router := mux.NewRouter()
 
-			// Protected routes (require auth) - using REAL auth middleware
+			// Protected routes (require auth + shop ownership) - using REAL middlewares
 			protectedShops := router.PathPrefix("/shops").Subrouter()
 			protectedShops.Use(authMiddleware.Authenticate)
+			protectedShops.Use(shopOwnershipMiddleware.Authorize)
 			protectedShops.HandleFunc("/{shop_id}", handler.GetByID).Methods("GET")
 			protectedShops.HandleFunc("/{shop_id}", handler.Update).Methods("PUT")
 
@@ -542,6 +547,179 @@ func (ctx *TestContext) SetupStoreTestApp() error {
 			router.HandleFunc("/stores/{slug}/products", handler.GetProducts).Methods("GET")
 			router.HandleFunc("/stores/{slug}/categories", handler.GetCategories).Methods("GET")
 			router.HandleFunc("/stores/{slug}", handler.GetBySlug).Methods("GET")
+
+			ctx.server = httptest.NewServer(router)
+		}),
+		fx.NopLogger, // Suppress fx logs during tests
+	)
+
+	return ctx.app.Start(context.Background())
+}
+
+// SetupCreateOrderTestApp initializes the test application for create order tests (public endpoint)
+func (ctx *TestContext) SetupCreateOrderTestApp() error {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+
+	// Initialize logger for tests
+	logs.Init()
+
+	// Setup SQL mock
+	db, sqlMock, err := sqlmock.New()
+	if err != nil {
+		return err
+	}
+	ctx.mockDB = db
+	ctx.mockSQLMock = sqlMock
+
+	// Allow queries to be executed in any order
+	sqlMock.MatchExpectationsInOrder(false)
+
+	// Create FX app with real services but mocked DB
+	ctx.app = fx.New(
+		fx.Provide(
+			// Provide mocked database connection
+			func() postgresql.DataBaseConnection {
+				return &mockDataBaseConnection{db: db}
+			},
+
+			// Provide repository dependencies
+			fx.Annotate(postgresql.NewShopRepository, fx.As(new(ports.ShopRepository))),
+			fx.Annotate(postgresql.NewProductRepository, fx.As(new(ports.ProductRepository))),
+			fx.Annotate(postgresql.NewPaymentMethodRepository, fx.As(new(ports.PaymentMethodRepository))),
+			fx.Annotate(postgresql.NewDeliveryMethodRepository, fx.As(new(ports.DeliveryMethodRepository))),
+			fx.Annotate(postgresql.NewOrderRepository, fx.As(new(ports.OrderRepository))),
+
+			// Provide services
+			fx.Annotate(services.NewStoreService, fx.As(new(ports.StoreService))),
+			fx.Annotate(services.NewOrderService, fx.As(new(ports.OrderService))),
+			fx.Annotate(stubs.NewOrderEventNotifier, fx.As(new(ports.OrderEventNotifier))),
+			fx.Annotate(stubs.NewAssetService, fx.As(new(ports.AssetService))),
+			fx.Annotate(services.NewShopService, fx.As(new(ports.ShopService))),
+			fx.Annotate(
+				services.NewPaginationService[*models.Order],
+				fx.As(new(ports.PaginationService[*models.Order])),
+			),
+
+			// Provide use cases (all 5 required by NewOrderHandler)
+			fx.Annotate(order.NewCreateOrderUseCase, fx.As(new(ports.CreateOrderUseCase))),
+			fx.Annotate(order.NewGetAllOrdersByShopIDUseCase, fx.As(new(ports.GetAllOrdersByShopIDUseCase))),
+			fx.Annotate(order.NewGetOrderByIDUseCase, fx.As(new(ports.GetOrderByIDUseCase))),
+			fx.Annotate(order.NewUpdateOrderStatusUseCase, fx.As(new(ports.UpdateOrderStatusUseCase))),
+			fx.Annotate(order.NewUpdateOrderUseCase, fx.As(new(ports.UpdateOrderUseCase))),
+
+			// Provide handler
+			fx.Annotate(authhttp.NewOrderHandler, fx.As(new(ports.OrderHandler))),
+		),
+		fx.Invoke(func(handler ports.OrderHandler) {
+			// Create HTTP router and server
+			router := mux.NewRouter()
+
+			// Public route: POST /stores/{slug}/orders
+			storeRouter := router.PathPrefix("/stores").Subrouter()
+			storeRouter.HandleFunc("/{slug}/orders", handler.Create).Methods("POST")
+
+			ctx.server = httptest.NewServer(router)
+		}),
+		fx.NopLogger, // Suppress fx logs during tests
+	)
+
+	return ctx.app.Start(context.Background())
+}
+
+// SetupOrderTestApp initializes the test application for order tests (protected endpoints)
+func (ctx *TestContext) SetupOrderTestApp() error {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+
+	// Initialize logger for tests
+	logs.Init()
+
+	// Setup SQL mock
+	db, sqlMock, err := sqlmock.New()
+	if err != nil {
+		return err
+	}
+	ctx.mockDB = db
+	ctx.mockSQLMock = sqlMock
+
+	// Allow queries to be executed in any order
+	sqlMock.MatchExpectationsInOrder(false)
+
+	// Create TokenService for auth middleware
+	tokenService := jwt.NewTokenService()
+
+	// Generate test token for authenticated requests
+	// - Shop 1, 2: standard test shops
+	// - Shop 888: for "not found" tests (passes auth, but order doesn't exist in DB)
+	// - Shop 999: intentionally excluded for "not owned" tests
+	testUser := &models.User{
+		ID:    1,
+		Email: "test@example.com",
+	}
+	testShopIDs := []int{1, 2, 888}
+	ctx.authToken, err = tokenService.Generate(context.Background(), testUser, testShopIDs)
+	if err != nil {
+		return err
+	}
+
+	// Create FX app with real services but mocked DB
+	ctx.app = fx.New(
+		fx.Provide(
+			// Provide mocked database connection
+			func() postgresql.DataBaseConnection {
+				return &mockDataBaseConnection{db: db}
+			},
+
+			// Provide TokenService for auth middleware
+			fx.Annotate(jwt.NewTokenService, fx.As(new(ports.TokenService))),
+
+			// Provide auth middleware
+			middleware.NewAuthMiddleware,
+
+			// Provide repository dependencies
+			fx.Annotate(postgresql.NewShopRepository, fx.As(new(ports.ShopRepository))),
+			fx.Annotate(postgresql.NewProductRepository, fx.As(new(ports.ProductRepository))),
+			fx.Annotate(postgresql.NewPaymentMethodRepository, fx.As(new(ports.PaymentMethodRepository))),
+			fx.Annotate(postgresql.NewDeliveryMethodRepository, fx.As(new(ports.DeliveryMethodRepository))),
+			fx.Annotate(postgresql.NewOrderRepository, fx.As(new(ports.OrderRepository))),
+
+			// Provide services
+			fx.Annotate(services.NewStoreService, fx.As(new(ports.StoreService))),
+			fx.Annotate(services.NewOrderService, fx.As(new(ports.OrderService))),
+			fx.Annotate(stubs.NewOrderEventNotifier, fx.As(new(ports.OrderEventNotifier))),
+			fx.Annotate(stubs.NewAssetService, fx.As(new(ports.AssetService))),
+			fx.Annotate(services.NewShopService, fx.As(new(ports.ShopService))),
+			fx.Annotate(
+				services.NewPaginationService[*models.Order],
+				fx.As(new(ports.PaginationService[*models.Order])),
+			),
+
+			// Provide use cases (all 5 required by NewOrderHandler)
+			fx.Annotate(order.NewCreateOrderUseCase, fx.As(new(ports.CreateOrderUseCase))),
+			fx.Annotate(order.NewGetAllOrdersByShopIDUseCase, fx.As(new(ports.GetAllOrdersByShopIDUseCase))),
+			fx.Annotate(order.NewGetOrderByIDUseCase, fx.As(new(ports.GetOrderByIDUseCase))),
+			fx.Annotate(order.NewUpdateOrderStatusUseCase, fx.As(new(ports.UpdateOrderStatusUseCase))),
+			fx.Annotate(order.NewUpdateOrderUseCase, fx.As(new(ports.UpdateOrderUseCase))),
+
+			// Provide handler
+			fx.Annotate(authhttp.NewOrderHandler, fx.As(new(ports.OrderHandler))),
+
+			// Provide shop ownership middleware
+			middleware.NewShopOwnershipMiddleware,
+		),
+		fx.Invoke(func(handler ports.OrderHandler, authMiddleware *middleware.AuthMiddleware, shopOwnershipMiddleware *middleware.ShopOwnershipMiddleware) {
+			// Create HTTP router and server
+			router := mux.NewRouter()
+
+			// Protected routes (require auth + shop ownership)
+			protected := router.PathPrefix("/shops").Subrouter()
+			protected.Use(authMiddleware.Authenticate)
+			protected.Use(shopOwnershipMiddleware.Authorize)
+			protected.HandleFunc("/{shop_id}/orders/{order_id:[0-9]+}/status", handler.UpdateStatus).Methods("PATCH")
+			protected.HandleFunc("/{shop_id}/orders/{order_id:[0-9]+}", handler.Update).Methods("PUT")
+			protected.HandleFunc("/{shop_id}/orders/{order_id:[0-9]+}", handler.GetByID).Methods("GET")
+			protected.HandleFunc("/{shop_id}/orders", handler.GetAll).Methods("GET")
 
 			ctx.server = httptest.NewServer(router)
 		}),

--- a/tests/integration/steps/update_order_status_steps.go
+++ b/tests/integration/steps/update_order_status_steps.go
@@ -1,0 +1,240 @@
+package steps
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cucumber/godog"
+
+	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/responses"
+)
+
+const (
+	scenarioStatusTransition = "status-transition"
+	scenarioStatusNotFound   = "status-not-found"
+	scenarioConcurrentModify = "concurrent-modification"
+
+	statusStepsItemsJSON = `[{"id":1,"product_id":10,"product_name":"Test Product","product_image_url":"","base_price":100,"is_promotional":false,"promotional_price":0,"quantity":2,"unit_price":100,"total_price":200,"notes":"","selected_options":[]}]`
+)
+
+type UpdateOrderStatusSteps struct {
+	currentStatus string
+}
+
+func NewUpdateOrderStatusSteps() *UpdateOrderStatusSteps {
+	return &UpdateOrderStatusSteps{}
+}
+
+// ===== Given Steps =====
+
+func (g *UpdateOrderStatusSteps) anOrderInShopHasStatus(orderID int, shopID int, status string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioStatusTransition
+	g.currentStatus = status
+	return nil
+}
+
+func (g *UpdateOrderStatusSteps) anOrderDoesNotExistInShopForStatusUpdate(orderID int, shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioStatusNotFound
+	return nil
+}
+
+func (g *UpdateOrderStatusSteps) anOrderInShopHasStatusButWillBeConcurrentlyModified(orderID int, shopID int, status string) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioConcurrentModify
+	g.currentStatus = status
+	return nil
+}
+
+// ===== When Steps =====
+
+func (g *UpdateOrderStatusSteps) iSendAnUpdateOrderStatusRequest(shopID int, orderID int, newStatus string) error {
+	ctx := GetTestContext()
+
+	if ctx.app == nil {
+		if err := ctx.SetupOrderTestApp(); err != nil {
+			return err
+		}
+	}
+
+	// Setup SQL expectations based on scenario
+	g.setupUpdateStatusSQLExpectations(ctx, shopID, orderID, newStatus)
+
+	body := map[string]string{"status": newStatus}
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/shops/%d/orders/%d/status", ctx.server.URL, shopID, orderID)
+	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if ctx.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+ctx.authToken)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	ctx.response = resp
+	g.parseStatusResponse(ctx, resp)
+
+	return nil
+}
+
+// ===== SQL Mock Setup =====
+
+func (g *UpdateOrderStatusSteps) setupUpdateStatusSQLExpectations(ctx *TestContext, shopID int, orderID int, newStatus string) {
+	getByIDColumns := []string{
+		"id", "order_number", "status",
+		"store_id", "store_name", "store_slug",
+		"customer_name", "customer_phone", "customer_email",
+		"customer_address_name", "customer_address_place_id",
+		"customer_address_lat", "customer_address_lng",
+		"payment_method_id", "payment_method_code", "payment_method_name",
+		"delivery_method_id", "delivery_method_code", "delivery_method_name",
+		"delivery_zone_id", "delivery_zone_name", "delivery_zone_price",
+		"subtotal", "shipping_cost", "total",
+		"created_at", "updated_at",
+		"items",
+	}
+
+	now := time.Now()
+
+	switch ctx.scenario {
+	case scenarioStatusTransition:
+		// Step 1: GetByID - fetch current order
+		rows1 := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", g.currentStatus,
+				shopID, "Test Store", "test-store",
+				"John Doe", "1234567890", "john@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				statusStepsItemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows1)
+
+		// Step 2: UPDATE status (optimistic lock)
+		ctx.mockSQLMock.ExpectExec("UPDATE orders SET status").
+			WithArgs(newStatus, orderID, shopID, g.currentStatus).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		// Step 3: GetByID - re-fetch with new status
+		rows2 := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", newStatus,
+				shopID, "Test Store", "test-store",
+				"John Doe", "1234567890", "john@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				statusStepsItemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows2)
+
+	case scenarioStatusNotFound:
+		emptyRows := sqlmock.NewRows(getByIDColumns)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(emptyRows)
+
+	case scenarioConcurrentModify:
+		// Step 1: GetByID - fetch current order
+		rows1 := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", g.currentStatus,
+				shopID, "Test Store", "test-store",
+				"John Doe", "1234567890", "john@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				statusStepsItemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows1)
+
+		// Step 2: UPDATE returns 0 rows affected (concurrent modification)
+		ctx.mockSQLMock.ExpectExec("UPDATE orders SET status").
+			WithArgs(newStatus, orderID, shopID, g.currentStatus).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+}
+
+func (g *UpdateOrderStatusSteps) parseStatusResponse(ctx *TestContext, resp *http.Response) {
+	if resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		var errorResponse map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err == nil {
+			ctx.errorMessage = errorResponse["error"]
+		}
+	} else {
+		var response responses.UpdateOrderStatusResponse
+		if err := json.NewDecoder(resp.Body).Decode(&response); err == nil {
+			ctx.responseBody = response.Order
+		}
+	}
+}
+
+// ===== Then Steps =====
+
+func (g *UpdateOrderStatusSteps) theResponseShouldContainTheOrderWithStatus(expectedStatus string) error {
+	ctx := GetTestContext()
+	order, ok := ctx.responseBody.(*responses.OrderResponse)
+	if !ok {
+		return fmt.Errorf("expected OrderResponse, got: %T", ctx.responseBody)
+	}
+	if order == nil {
+		return fmt.Errorf("expected order in response, got nil")
+	}
+	if order.Status != expectedStatus {
+		return fmt.Errorf("expected order status '%s', got '%s'", expectedStatus, order.Status)
+	}
+	return nil
+}
+
+// ===== Register Steps =====
+
+func (g *UpdateOrderStatusSteps) RegisterSteps(sc *godog.ScenarioContext) {
+	// Given steps
+	sc.Step(`^an order with ID (\d+) in shop (\d+) has status "([^"]*)"$`, g.anOrderInShopHasStatus)
+	sc.Step(`^an order with ID (\d+) does not exist in shop (\d+) for status update$`, g.anOrderDoesNotExistInShopForStatusUpdate)
+	sc.Step(`^an order with ID (\d+) in shop (\d+) has status "([^"]*)" but will be concurrently modified$`, g.anOrderInShopHasStatusButWillBeConcurrentlyModified)
+
+	// When steps
+	sc.Step(`^I send an update order status request for shop (\d+) and order (\d+) with status "([^"]*)"$`, g.iSendAnUpdateOrderStatusRequest)
+
+	// Then steps
+	sc.Step(`^the response should contain the order with status "([^"]*)"$`, g.theResponseShouldContainTheOrderWithStatus)
+}

--- a/tests/integration/steps/update_order_steps.go
+++ b/tests/integration/steps/update_order_steps.go
@@ -1,0 +1,474 @@
+package steps
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cucumber/godog"
+
+	"github.com/mlgaray/ecommerce_api/internal/infraestructure/adapters/http/contracts/responses"
+)
+
+const (
+	scenarioUpdateOrderEditable      = "update-order-editable"
+	scenarioUpdateOrderDeliveryZone  = "update-order-delivery-zone"
+	scenarioUpdateOrderCompleted     = "update-order-completed"
+	scenarioUpdateOrderCancelled     = "update-order-cancelled"
+	scenarioUpdateOrderNotFound      = "update-order-not-found"
+	scenarioUpdateOrderSubtotalWrong = "update-order-subtotal-wrong"
+
+	updateOrderResultJSON       = `{"updated_at": "2026-01-02T00:00:00Z", "subtotal": 300, "total": 350}`
+	updateOrderUpdatedItemsJSON = `[{"id":1,"product_id":10,"product_name":"Test Product","product_image_url":"","base_price":100,"is_promotional":false,"promotional_price":0,"quantity":3,"unit_price":100,"total_price":300,"notes":"","selected_options":[]}]`
+)
+
+type UpdateOrderSteps struct{}
+
+func NewUpdateOrderSteps() *UpdateOrderSteps {
+	return &UpdateOrderSteps{}
+}
+
+// ===== Helper: build update request body =====
+
+func (g *UpdateOrderSteps) buildUpdateOrderRequest() map[string]interface{} {
+	return map[string]interface{}{
+		"order": map[string]interface{}{
+			"customer": map[string]interface{}{
+				"name":  "Jane Doe Updated",
+				"phone": "9876543210",
+				"email": "jane@example.com",
+			},
+			"payment_method": map[string]interface{}{
+				"id":   1,
+				"name": "Transfer",
+				"code": "transfer",
+			},
+			"delivery_method": map[string]interface{}{
+				"id":            1,
+				"name":          "Delivery",
+				"code":          "delivery",
+				"shipping_cost": 50.0,
+			},
+			"items": []map[string]interface{}{
+				{
+					"product": map[string]interface{}{
+						"id":    10,
+						"name":  "Test Product",
+						"price": 100.0,
+					},
+					"quantity":   3,
+					"unit_price": 100.0,
+				},
+			},
+			"subtotal": 300.0,
+			"total":    350.0,
+		},
+	}
+}
+
+// ===== Given Steps =====
+
+func (g *UpdateOrderSteps) anEditableOrderExistsInShop(orderID int, shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioUpdateOrderEditable
+	return nil
+}
+
+func (g *UpdateOrderSteps) anEditableOrderExistsInShopWithDeliveryZones(orderID int, shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioUpdateOrderDeliveryZone
+	return nil
+}
+
+func (g *UpdateOrderSteps) aCompletedOrderExistsInShop(orderID int, shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioUpdateOrderCompleted
+	return nil
+}
+
+func (g *UpdateOrderSteps) aCancelledOrderExistsInShop(orderID int, shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioUpdateOrderCancelled
+	return nil
+}
+
+func (g *UpdateOrderSteps) anOrderDoesNotExistInShopForUpdate(orderID int, shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioUpdateOrderNotFound
+	return nil
+}
+
+func (g *UpdateOrderSteps) anEditableOrderExistsInShopForSubtotalValidation(orderID int, shopID int) error {
+	ctx := GetTestContext()
+	ctx.scenario = scenarioUpdateOrderSubtotalWrong
+	return nil
+}
+
+// ===== When Steps =====
+
+func (g *UpdateOrderSteps) iSendAnUpdateOrderRequest(shopID int, orderID int) error {
+	ctx := GetTestContext()
+	ctx.requestBody = g.buildUpdateOrderRequest()
+	return g.sendUpdateRequest(ctx, shopID, orderID)
+}
+
+func (g *UpdateOrderSteps) iSendAnUpdateOrderRequestWithDeliveryZone(shopID int, orderID int) error {
+	ctx := GetTestContext()
+	req := g.buildUpdateOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	dm, err := getSubMap(order, "delivery_method")
+	if err != nil {
+		return err
+	}
+	dm["delivery_zone"] = map[string]interface{}{
+		"id":    1,
+		"name":  "Zone A",
+		"price": 50.0,
+	}
+	ctx.requestBody = req
+	return g.sendUpdateRequest(ctx, shopID, orderID)
+}
+
+func (g *UpdateOrderSteps) iSendAnUpdateOrderRequestWithWrongSubtotal(shopID int, orderID int) error {
+	ctx := GetTestContext()
+	req := g.buildUpdateOrderRequest()
+	order, err := getOrderFromReq(req)
+	if err != nil {
+		return err
+	}
+	order["subtotal"] = 999.0
+	order["total"] = 1049.0
+	ctx.requestBody = req
+	return g.sendUpdateRequest(ctx, shopID, orderID)
+}
+
+func (g *UpdateOrderSteps) sendUpdateRequest(ctx *TestContext, shopID int, orderID int) error {
+	if ctx.app == nil {
+		if err := ctx.SetupOrderTestApp(); err != nil {
+			return err
+		}
+	}
+
+	// Setup SQL expectations
+	g.setupUpdateOrderSQLExpectations(ctx, shopID, orderID)
+
+	jsonBody, err := json.Marshal(ctx.requestBody)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/shops/%d/orders/%d", ctx.server.URL, shopID, orderID)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if ctx.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+ctx.authToken)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	ctx.response = resp
+	g.parseUpdateOrderResponse(ctx, resp)
+
+	return nil
+}
+
+// ===== SQL Mock Setup =====
+
+func (g *UpdateOrderSteps) setupUpdateOrderSQLExpectations(ctx *TestContext, shopID int, orderID int) {
+	getByIDColumns := []string{
+		"id", "order_number", "status",
+		"store_id", "store_name", "store_slug",
+		"customer_name", "customer_phone", "customer_email",
+		"customer_address_name", "customer_address_place_id",
+		"customer_address_lat", "customer_address_lng",
+		"payment_method_id", "payment_method_code", "payment_method_name",
+		"delivery_method_id", "delivery_method_code", "delivery_method_name",
+		"delivery_zone_id", "delivery_zone_name", "delivery_zone_price",
+		"subtotal", "shipping_cost", "total",
+		"created_at", "updated_at",
+		"items",
+	}
+
+	shopColumns := []string{
+		"id", "name", "slug", "email", "phone", "instagram", "primary_color",
+		"images", "address", "payment_methods", "delivery_methods", "operating_schedules", "timezone",
+	}
+
+	productColumns := []string{
+		"id", "name", "price", "is_stockeable", "stock", "is_active",
+		"is_promotional", "promotional_price", "variants",
+	}
+
+	now := time.Now()
+	itemsJSON := `[{"id":1,"product_id":10,"product_name":"Test Product","product_image_url":"","base_price":100,"is_promotional":false,"promotional_price":0,"quantity":2,"unit_price":100,"total_price":200,"notes":"","selected_options":[]}]`
+
+	switch ctx.scenario {
+	case scenarioUpdateOrderEditable:
+		// Step 1: GetByID - existing editable order (pending)
+		rows1 := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", "pending",
+				shopID, "Test Store", "test-store",
+				"John Doe", "1234567890", "john@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				itemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows1)
+
+		// Step 2: ValidateOrderItems -> GetByIDsAndShopID
+		productRows := sqlmock.NewRows(productColumns).
+			AddRow(10, "Test Product", 100.0, false, 0, true, false, 0, "[]")
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM products").
+			WillReturnRows(productRows)
+
+		// Step 3: ValidateDeliveryMethod -> GetBySlug
+		shopRows := sqlmock.NewRows(shopColumns).
+			AddRow(shopID, "Test Store", "test-store", "store@test.com", "+54111234567", "@teststore", nil,
+				"[]",
+				`{"id": 1, "name": "Main St", "place_id": "ChIJ", "lat": -34.6, "lng": -58.38}`,
+				`[{"id": 1, "name": "Transfer", "code": "transfer", "is_active": true}]`,
+				`[{"id": 1, "name": "Delivery", "code": "delivery", "is_active": true, "delivery_config": {"fixed_price": 50}}]`,
+				"[]", nil)
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM shops").
+			WillReturnRows(shopRows)
+
+		// Step 4: update_order stored procedure
+		ctx.mockSQLMock.ExpectQuery("SELECT update_order").
+			WillReturnRows(sqlmock.NewRows([]string{"update_order"}).AddRow(updateOrderResultJSON))
+
+		// Step 5: GetByID re-fetch
+		rows2 := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", "pending",
+				shopID, "Test Store", "test-store",
+				"Jane Doe Updated", "9876543210", "jane@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				300.0, 50.0, 350.0,
+				now, now,
+				updateOrderUpdatedItemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows2)
+
+	case scenarioUpdateOrderDeliveryZone:
+		// Step 1: GetByID
+		rows1 := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", "pending",
+				shopID, "Test Store", "test-store",
+				"John Doe", "1234567890", "john@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				itemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows1)
+
+		// Step 2: Products
+		productRows := sqlmock.NewRows(productColumns).
+			AddRow(10, "Test Product", 100.0, false, 0, true, false, 0, "[]")
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM products").
+			WillReturnRows(productRows)
+
+		// Step 3: GetBySlug (with delivery zones)
+		shopRows := sqlmock.NewRows(shopColumns).
+			AddRow(shopID, "Test Store", "test-store", "store@test.com", "+54111234567", "@teststore", nil,
+				"[]",
+				`{"id": 1, "name": "Main St", "place_id": "ChIJ", "lat": -34.6, "lng": -58.38}`,
+				`[{"id": 1, "name": "Transfer", "code": "transfer", "is_active": true}]`,
+				`[{"id": 1, "name": "Delivery", "code": "delivery", "is_active": true, "delivery_zones": [{"id": 1, "name": "Zone A", "price": 50}]}]`,
+				"[]", nil)
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM shops").
+			WillReturnRows(shopRows)
+
+		// Step 4: update_order
+		ctx.mockSQLMock.ExpectQuery("SELECT update_order").
+			WillReturnRows(sqlmock.NewRows([]string{"update_order"}).AddRow(updateOrderResultJSON))
+
+		// Step 5: GetByID re-fetch
+		rows2 := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", "pending",
+				shopID, "Test Store", "test-store",
+				"Jane Doe Updated", "9876543210", "jane@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				1, "Zone A", 50.0,
+				300.0, 50.0, 350.0,
+				now, now,
+				updateOrderUpdatedItemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows2)
+
+	case scenarioUpdateOrderCompleted:
+		// GetByID returns completed order
+		rows := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", "completed",
+				shopID, "Test Store", "test-store",
+				"John Doe", "1234567890", "john@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				itemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows)
+
+	case scenarioUpdateOrderCancelled:
+		// GetByID returns cancelled order
+		rows := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", "cancelled",
+				shopID, "Test Store", "test-store",
+				"John Doe", "1234567890", "john@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				itemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows)
+
+	case scenarioUpdateOrderNotFound:
+		emptyRows := sqlmock.NewRows(getByIDColumns)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(emptyRows)
+
+	case scenarioUpdateOrderSubtotalWrong:
+		// Step 1: GetByID
+		rows1 := sqlmock.NewRows(getByIDColumns).
+			AddRow(
+				orderID, "ORD-001", "pending",
+				shopID, "Test Store", "test-store",
+				"John Doe", "1234567890", "john@example.com",
+				nil, nil, nil, nil,
+				1, "transfer", "Transfer",
+				1, "delivery", "Delivery",
+				nil, nil, nil,
+				200.0, 50.0, 250.0,
+				now, now,
+				itemsJSON,
+			)
+		ctx.mockSQLMock.ExpectQuery("WITH items_with_selections").
+			WithArgs(orderID, shopID).
+			WillReturnRows(rows1)
+
+		// Step 2: Products
+		productRows := sqlmock.NewRows(productColumns).
+			AddRow(10, "Test Product", 100.0, false, 0, true, false, 0, "[]")
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM products").
+			WillReturnRows(productRows)
+
+		// Step 3: GetBySlug for delivery validation
+		shopRows := sqlmock.NewRows(shopColumns).
+			AddRow(shopID, "Test Store", "test-store", "store@test.com", "+54111234567", "@teststore", nil,
+				"[]",
+				`{"id": 1, "name": "Main St", "place_id": "ChIJ", "lat": -34.6, "lng": -58.38}`,
+				`[{"id": 1, "name": "Transfer", "code": "transfer", "is_active": true}]`,
+				`[{"id": 1, "name": "Delivery", "code": "delivery", "is_active": true, "delivery_config": {"fixed_price": 50}}]`,
+				"[]", nil)
+		ctx.mockSQLMock.ExpectQuery("SELECT (.+) FROM shops").
+			WillReturnRows(shopRows)
+
+		// No step 4: fails at CalculateAndValidateTotals
+	}
+}
+
+func (g *UpdateOrderSteps) parseUpdateOrderResponse(ctx *TestContext, resp *http.Response) {
+	if resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		var errorResponse map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err == nil {
+			ctx.errorMessage = errorResponse["error"]
+		}
+	} else {
+		var response responses.UpdateOrderResponse
+		if err := json.NewDecoder(resp.Body).Decode(&response); err == nil {
+			ctx.responseBody = response.Order
+		}
+	}
+}
+
+// ===== Then Steps =====
+
+func (g *UpdateOrderSteps) theResponseShouldContainTheUpdatedOrder() error {
+	ctx := GetTestContext()
+	order, ok := ctx.responseBody.(*responses.OrderResponse)
+	if !ok {
+		return fmt.Errorf("expected OrderResponse, got: %T", ctx.responseBody)
+	}
+	if order == nil || order.ID == 0 {
+		return fmt.Errorf("expected order with ID, got ID 0")
+	}
+	if order.OrderNumber == "" {
+		return fmt.Errorf("expected order with order_number, got empty")
+	}
+	return nil
+}
+
+// ===== Register Steps =====
+
+func (g *UpdateOrderSteps) RegisterSteps(sc *godog.ScenarioContext) {
+	// Given steps
+	sc.Step(`^an editable order with ID (\d+) exists in shop (\d+)$`, g.anEditableOrderExistsInShop)
+	sc.Step(`^an editable order with ID (\d+) exists in shop (\d+) with delivery zones$`, g.anEditableOrderExistsInShopWithDeliveryZones)
+	sc.Step(`^a completed order with ID (\d+) exists in shop (\d+)$`, g.aCompletedOrderExistsInShop)
+	sc.Step(`^a cancelled order with ID (\d+) exists in shop (\d+)$`, g.aCancelledOrderExistsInShop)
+	sc.Step(`^an order with ID (\d+) does not exist in shop (\d+) for update$`, g.anOrderDoesNotExistInShopForUpdate)
+	sc.Step(`^an editable order with ID (\d+) exists in shop (\d+) for subtotal validation$`, g.anEditableOrderExistsInShopForSubtotalValidation)
+
+	// When steps
+	sc.Step(`^I send an update order request for shop (\d+) and order (\d+)$`, g.iSendAnUpdateOrderRequest)
+	sc.Step(`^I send an update order request with delivery zone for shop (\d+) and order (\d+)$`, g.iSendAnUpdateOrderRequestWithDeliveryZone)
+	sc.Step(`^I send an update order request with wrong subtotal for shop (\d+) and order (\d+)$`, g.iSendAnUpdateOrderRequestWithWrongSubtotal)
+
+	// Then steps
+	sc.Step(`^the response should contain the updated order$`, g.theResponseShouldContainTheUpdatedOrder)
+}

--- a/tests/integration/stubs/order_event_notifier.go
+++ b/tests/integration/stubs/order_event_notifier.go
@@ -1,0 +1,21 @@
+package stubs
+
+import (
+	"context"
+
+	"github.com/mlgaray/ecommerce_api/internal/core/models"
+)
+
+// OrderEventNotifier is a stub implementation for integration tests.
+// Notifications are fire-and-forget so this is a no-op.
+type OrderEventNotifier struct{}
+
+// NewOrderEventNotifier creates a new stub OrderEventNotifier.
+func NewOrderEventNotifier() *OrderEventNotifier {
+	return &OrderEventNotifier{}
+}
+
+// NotifyNewOrder is a no-op for tests.
+func (n *OrderEventNotifier) NotifyNewOrder(ctx context.Context, order *models.Order) {
+	// No-op: notifications are irrelevant for integration tests
+}


### PR DESCRIPTION
## Summary
- **Fix IDOR on GET /shops/{shop_id}/orders**: endpoint was missing shop ownership verification, allowing authenticated users to access any shop's orders
- **Add ShopOwnershipMiddleware**: centralized authorization replacing duplicated `userOwnsShop` checks across 5 handlers into a single middleware on the protected `/shops` subrouter
- **Add BDD integration tests** for all order endpoints (create, get_all, get_by_id, update, update_status) including access denied scenarios
- **Increase test coverage** to 100% for order use cases, service, and domain errors

## Test plan
- [ ] `go test ./internal/infraestructure/adapters/http/middleware/...` — middleware unit tests (8 cases)
- [ ] `go test ./internal/infraestructure/adapters/http/...` — handler tests pass without duplicated auth checks
- [ ] `go test ./tests/integration/...` — 186 BDD scenarios pass (4 new for GetAll orders)
- [ ] `go test ./...` — full suite green
- [ ] `golangci-lint run ./...` — no lint issues
- [ ] Transparent to frontend — no contract changes, same error codes (400/403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)